### PR TITLE
Support for with-registry-auth flag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,11 +37,26 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: "Install required tools"
-        run: sudo apt-get install apache2-utils
-
       - name: "Checkout"
         uses: actions/checkout@v4
+
+      - name: "Put private key in a file"
+        run: |
+          echo "${{ secrets.DOCKER_SSH_KEY }}" > ansible/ssh_key
+          chmod 600 ansible/ssh_key
+          export ANSIBLE_HOST_KEY_CHECKING=False
+
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: actions_test.yml
+          directory: ansible
+          options: |
+            -u ${{ secrets.DOCKER_USER }}
+            --private-key ./ssh_key
+            -i ${{ secrets.DOCKER_HOST }},
+            -c ssh
+            -e "ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
 
       - name: "Write YAML"
         id: yaml-action
@@ -50,32 +65,13 @@ jobs:
           data: '{"version":"3.8","services":{"alpine":{"image":"localhost:5000/alpine","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
-      - name: "Create Registry User"
-        run: |
-          mkdir -p ./registry
-          htpasswd -Bbn testuser testpassword > ./registry/registry.password
-
-      - name: "Spool Private Docker Registry"
-        run: |
-          docker run -d -p 5000:5000 -e REGISTRY_AUTH="htpasswd" -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH="/auth/registry.password" -v ./registry/registry.password:/auth/registry.password --name registry registry:2
-
-      - name: "login to Registry"
-        run: |
-          echo testpassword | docker login localhost:5000 -u testuser --password-stdin
-
-      - name: "Push Image to Registry"
-        run: |
-          docker pull alpine
-          docker tag alpine localhost:5000/alpine
-          docker push localhost:5000/alpine
-
       - name: "Test Local Action with Registry Auth"
         id: test
         uses: ./
         with:
-          host: localhost
-          user: testuser
-          pass: testpassword
+          host: ${{ secrets.DOCKER_HOST }}
+          user: ${{ secrets.DOCKER_USER }}
+          ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
           file: "docker-compose.yaml"
           name: "test-private-stack"
           with_registry_auth: "true"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,12 +26,59 @@ jobs:
         uses: ./
         with:
           host: ${{ secrets.DOCKER_HOST }}
-          port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
-          #pass: ${{ secrets.DOCKER_PASS }}
           ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
           file: "docker-compose.yaml"
           name: "test-stack"
+
+  test_registry_auth:
+    name: "Test Registry Auth"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: "Install required tools"
+        run: sudo apt-get install apache2-utils
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Write YAML"
+        id: yaml-action
+        uses: teunmooij/yaml@v1
+        with:
+          data: '{"version":"3.8","services":{"alpine":{"image":"alpine","command":"tail -f /dev/null"}}}'
+          to-file: "docker-compose.yaml"
+
+      - name: "Spool Private Docker Registry"
+        run: |
+          docker run -d -p 5000:5000 -e REGISTRY_AUTH="htpasswd" -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH="/auth/registry.password" -v ./registry/registry.password:/auth/registry.password --name registry registry:2
+
+      - name: "Create Registry User"
+        run: |
+          mkdir -p auth
+          htpasswd -Bbn testuser testpassword > auth/registry.password
+
+      - name: "login to Registry"
+        run: |
+          docker login localhost:5000 -u testuser -p testpassword
+
+      - name: "Push Image to Registry"
+        run: |
+          docker pull alpine
+          docker tag alpine localhost:5000/alpine
+          docker push localhost:5000/alpine
+
+      - name: "Test Local Action with Registry Auth"
+        id: test
+        uses: ./
+        with:
+          host: localhost
+          user: testuser
+          pass: testpassword
+          file: "docker-compose.yaml"
+          name: "test-private-stack"
+          with_registry_auth: "true"
 
   lint:
     name: "Lint"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,6 +71,7 @@ jobs:
         uses: ./
         with:
           host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
           file: "docker-compose.yaml"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,14 +50,14 @@ jobs:
           data: '{"version":"3.8","services":{"alpine":{"image":"alpine","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
+      - name: "Create Registry User"
+        run: |
+          mkdir -p ./registry
+          htpasswd -Bbn testuser testpassword > ./registry/registry.password
+
       - name: "Spool Private Docker Registry"
         run: |
           docker run -d -p 5000:5000 -e REGISTRY_AUTH="htpasswd" -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH="/auth/registry.password" -v ./registry/registry.password:/auth/registry.password --name registry registry:2
-
-      - name: "Create Registry User"
-        run: |
-          mkdir -p auth
-          htpasswd -Bbn testuser testpassword > auth/registry.password
 
       - name: "login to Registry"
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,10 +41,16 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: "Put private key in a file"
+      - name: "Create SSH directory"
+        run: mkdir -p ~/.ssh
+
+      - name: "Add private key to SSH agent"
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.DOCKER_SSH_KEY }}
+
+      - name: "Do not check host key"
         run: |
-          echo "${{ secrets.DOCKER_SSH_KEY }}" > ansible/ssh_key
-          chmod 600 ansible/ssh_key
           export ANSIBLE_HOST_KEY_CHECKING=False
 
       - name: Run playbook

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
         id: yaml-action
         uses: teunmooij/yaml@v1
         with:
-          data: '{"version":"3.8","services":{"alpine":{"image":"alpine","command":"tail -f /dev/null"}}}'
+          data: '{"version":"3.8","services":{"alpine":{"image":"localhost:5000/alpine","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
       - name: "Create Registry User"
@@ -61,7 +61,7 @@ jobs:
 
       - name: "login to Registry"
         run: |
-          docker login localhost:5000 -u testuser -p testpassword
+          echo testpassword | docker login localhost:5000 -u testuser --password-stdin
 
       - name: "Push Image to Registry"
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: ./
         with:
           host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
           file: "docker-compose.yaml"

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,10 @@ inputs:
   env_file:
     description: "Environment File"
     required: false
+  with_registry_auth:
+    description: "Use registry authentication"
+    required: false
+    default: "false"
 
 runs:
   using: "docker"

--- a/ansible/actions_test.yml
+++ b/ansible/actions_test.yml
@@ -1,0 +1,53 @@
+---
+- name: Test Registry Auth
+  hosts: all
+  become: no
+  tasks:
+    - name: Assert apache2-utils is present
+      command: dpkg -l apache2-utils
+      register: result
+      failed_when: result.rc != 0
+      changed_when: false
+
+    - name: Create registry directory
+      file:
+        path: /tmp/registry
+        state: directory
+
+    - name: Create registry user
+      shell: htpasswd -Bbn testuser testpassword > /tmp/registry/registry.password
+      changed_when: false
+
+    - name: Create Docker registry container
+      docker_container:
+        name: registry
+        image: registry:2
+        ports:
+          - "5000:5000"
+        volumes:
+          - /tmp/registry/registry.password:/auth/registry.password:ro
+        env:
+          REGISTRY_AUTH: "htpasswd"
+          REGISTRY_AUTH_HTPASSWD_REALM: "Registry Realm"
+          REGISTRY_AUTH_HTPASSWD_PATH: "/auth/registry.password"
+        state: started
+
+    - name: Login to Docker registry
+      docker_login:
+        registry: localhost:5000
+        username: testuser
+        password: testpassword
+
+    - name: pull alpine image from Docker Hub
+      docker_image:
+        name: alpine
+        tag: latest
+        source: pull
+
+    - name: Push alpine image to local registry
+      docker_image:
+        name: alpine
+        repository: localhost:5000/alpine
+        tag: latest
+        push: true
+        source: local

--- a/src/main.sh
+++ b/src/main.sh
@@ -60,5 +60,10 @@ if [ -n "${INPUT_ENV_FILE}" ];then
     # export ENV_FILE="${INPUT_ENV_FILE}"
 fi
 
+DEPLOY_CMD="docker stack deploy -c \"${INPUT_FILE}\" \"${INPUT_NAME}\""
+if [ "${INPUT_WITH_REGISTRY_AUTH}" == "true" ]; then
+    DEPLOY_CMD="$DEPLOY_CMD --with-registry-auth"
+fi
+
 echo -e "\u001b[36mDeploying Stack: \u001b[37;1m${INPUT_NAME}"
-docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}"
+eval "${DEPLOY_CMD}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -62,6 +62,7 @@ fi
 
 DEPLOY_CMD="docker stack deploy -c \"${INPUT_FILE}\" \"${INPUT_NAME}\""
 if [ "${INPUT_WITH_REGISTRY_AUTH}" == "true" ]; then
+    echo -e "\u001b[36mAdding with-registry-auth flag to command."
     DEPLOY_CMD="$DEPLOY_CMD --with-registry-auth"
 fi
 


### PR DESCRIPTION
Hello,

I've worked on an implementation for the `with-registry-auth` flag.

My current test works by reusing the `DOCKER_HOST`, `DOCKER_SSH_KEY`, `DOCKER_USER` vars to deploy a new stack specifically for the flag.

I'm using an ansible playbook to deploy a simple docker registry to the `DOCKER_HOST`, login in to it and pushing the latest alpine image for the test.

I've added the `with_registry_auth` input in the `action.yml` file.

tested on Ubuntu 24.04.1 LTS