### PR TITLE
Add new registry_auth value that does docker login and pass the --with-registry-auth flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input    | required | default               | description               |
-| -------- | -------- | --------------------- | ------------------------- |
-| host     | **Yes**  | -                     | Remote Docker hostname    |
-| port     | No       | `22`                  | Remote Docker port        |
-| user     | **Yes**  | -                     | Remote Docker username    |
-| pass     | No       | -                     | Remote Docker password \* |
-| ssh_key  | No       | -                     | Remote SSH Key file \*    |
-| file     | No       | `docker-compose.yaml` | Docker Compose file       |
-| name     | **Yes**  | -                     | Docker Stack name         |
-| env_file | No       | -                     | Docker Environment file   |
+| input         | required | default               | description                   |
+| ------------- | -------- | --------------------- | ----------------------------- |
+| host          | **Yes**  | -                     | Remote Docker hostname        |
+| port          | No       | `22`                  | Remote Docker port            |
+| user          | **Yes**  | -                     | Remote Docker username        |
+| pass          | No       | -                     | Remote Docker password \*     |
+| ssh_key       | No       | -                     | Remote SSH Key file \*        |
+| file          | No       | `docker-compose.yaml` | Docker Compose file           |
+| name          | **Yes**  | -                     | Docker Stack name             |
+| env_file      | No       | -                     | Docker Environment file       |
+| registry_auth | No       | -                     | Docker Login for Private Repo |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`
 
@@ -138,6 +139,35 @@ jobs:
           ssh_key: '${{ secrets.DOCKER_SSH_KEY }}'
           file: 'docker-compose-swarm.yaml'
           name: 'stack-name'
+```
+
+Private Github Docker Image with Key Example
+
+```yaml
+name: 'Test Docker Stack Deploy'
+
+on:
+  push:
+
+jobs:
+  deploy:
+    name: 'Deploy'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Docker Stack Deploy'
+        uses: cssnr/stack-deploy-action@v1
+        with:
+          name: 'stack-name'
+          file: 'docker-compose-swarm.yaml'
+          host: ${{ secrets.DOCKER_HOST }}
+          user: ${{ secrets.DOCKER_USER }}
+          ssh_key: '${{ secrets.DOCKER_SSH_KEY }}'
+          registry_auth: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 ```
 
 # Support

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,9 @@ inputs:
   env_file:
     description: "Environment File"
     required: false
+  registry_auth:
+    description: "Command to register your private repo using docker login for deploy context"
+    required: false
 
 runs:
   using: "docker"

--- a/src/main.sh
+++ b/src/main.sh
@@ -60,5 +60,12 @@ if [ -n "${INPUT_ENV_FILE}" ];then
     # export ENV_FILE="${INPUT_ENV_FILE}"
 fi
 
+DEPLOY_CMD="docker stack deploy -c \"${INPUT_FILE}\" \"${INPUT_NAME}\""
+if [ -n "${INPUT_REGISTRY_AUTH}" ];then
+    echo -e "\u001b[36mRunning register auth command."
+    eval "${INPUT_REGISTRY_AUTH}"
+    DEPLOY_CMD="$DEPLOY_CMD --with-registry-auth"
+fi
+
 echo -e "\u001b[36mDeploying Stack: \u001b[37;1m${INPUT_NAME}"
-docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}"
+eval "${DEPLOY_CMD}"


### PR DESCRIPTION
This would replace: https://github.com/cssnr/stack-deploy-action/pull/8

Tested on a real Github deploy step which was a lot like the example I added to the README:
```
deploy:
    runs-on: ubuntu-latest
    needs:
      - build-and-push-image
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          token: ${{ secrets.MY_PERSONAL_ACCESS_TOKEN }}

      - name: create env file
        run: |
          echo "GIT_COMMIT_HASH=${{ github.sha }}" >> ./envfile

      - name: Docker Stack Deploy
        uses: jtwebman/stack-deploy-action@proposed_registry_login_change
        with:
          name: serviceleadpages
          file: docker-stack.yaml
          host: serviceleadpages.com
          user: deploy
          ssh_key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
          registry_auth: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
          env_file: ./envfile
```

Logs of the output show it push the serviceleadpages_web image as I build the image with a tag of the commit hash and then pass that in the envfile for the docker-stack.yaml file to use.
```
Running: /main.sh as: root in: /github/workspace
# serviceleadpages.com:22 SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu[13](https://github.com/jtwebman/serviceleadpages/actions/runs/12249867855/job/34171916216#step:5:14).5
# serviceleadpages.com:22 SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5
# serviceleadpages.com:22 SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5
# serviceleadpages.com:22 SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5
# serviceleadpages.com:22 SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5
Adding SSH Key to SSH Agent
Agent pid [14](https://github.com/jtwebman/serviceleadpages/actions/runs/12249867855/job/34171916216#step:5:15)
Identity added: /root/.ssh/id_rsa (deploy@serviceleadpages.com)
Verifying Docker and Setting Context.
remote
Successfully created context "remote"
NAME        DESCRIPTION                               DOCKER ENDPOINT                        ERROR
default *   Current DOCKER_HOST based configuration   unix:///var/run/docker.sock            
remote                                                ssh://deploy@serviceleadpages.com:22   
remote
Current context is now "remote"
Sourcing Environment File: ./envfile
  File: ./envfile
  Size: 57        	Blocks: 8          IO Block: 4096   regular file
Device: 801h/2049d	Inode: 272938      Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1001/ UNKNOWN)   Gid: (  118/ UNKNOWN)
Access: 2024-12-10 05:[15](https://github.com/jtwebman/serviceleadpages/actions/runs/12249867855/job/34171916216#step:5:16):16.652585259 +0000
Modify: 2024-12-10 05:15:16.652585259 +0000
Change: 2024-12-10 05:15:[16](https://github.com/jtwebman/serviceleadpages/actions/runs/12249867855/job/34171916216#step:5:17).652585259 +0000
Running register auth command.
WARNING! Your password will be stored unencrypted in /github/home/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store
Login Succeeded
Deploying Stack: serviceleadpages
Updating service serviceleadpages_traefik (id: taak9fzihztr0nv8xuiss8t1y)
Updating service serviceleadpages_web (id: eoi1e55lk60s7[21](https://github.com/jtwebman/serviceleadpages/actions/runs/12249867855/job/34171916216#step:5:22)r0yfnfluob)
Updating service serviceleadpages_db (id: hwrdq8xw0ikl1kaeudo4l82i0)
Finished Success.
```