### PR TITLE
Improve Docker context handling with update and existence check

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -46,7 +46,11 @@ trap cleanup_trap EXIT HUP INT QUIT PIPE TERM
 echo -e "\u001b[36mVerifying Docker and Setting Context."
 ssh -p "${INPUT_PORT}" "${INPUT_USER}@${INPUT_HOST}" "docker info" > /dev/null
 
-docker context create remote --docker "host=ssh://${INPUT_USER}@${INPUT_HOST}:${INPUT_PORT}"
+if ! docker context inspect remote >/dev/null 2>&1; then
+    docker context create remote --docker "host=ssh://${INPUT_USER}@${INPUT_HOST}:${INPUT_PORT}"
+else
+    docker context update remote --docker "host=ssh://${INPUT_USER}@${INPUT_HOST}:${INPUT_PORT}"
+fi
 docker context ls
 docker context use remote
 


### PR DESCRIPTION
First, I want to thank you for the work you've put into this GitHub Action.

I encountered some issues with the creation of the Docker context on my self-hosted GitHub Actions runner. It seems like the context might be cached.

In my PR, I first check whether the context exists. If it doesn’t, a new one is created; otherwise, the remote context is updated.

To test this, I forked the repository into the repo where I wanted to use the action and referenced the path to the action in my repository. It worked for me.

![Bildschirmfoto 2025-02-03 um 20 50 31](https://github.com/user-attachments/assets/c8a3a477-3bac-42c1-9d8d-d75cb3982a96)
