### PR TITLE
Add Registry Authentication

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master]
 
+env:
+  PRIVATE_IMAGE: "smashedr/alpine-private" # amd64/arm64
+
 jobs:
   test:
     name: "Test"
@@ -37,7 +40,7 @@ jobs:
       - name: "Write YAML Private"
         uses: teunmooij/yaml@v1
         with:
-          data: '{"version":"3.8","services":{"alpine":{"image":"smashedr/alpine-private","command":"tail -f /dev/null"}}}'
+          data: '{"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
       - name: "Test Action Private"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,9 @@ name: "Test"
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches: [master]
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,24 +16,46 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
 
-      - name: "Write YAML"
+      - name: "Write YAML Basic"
         id: yaml-action
         uses: teunmooij/yaml@v1
         with:
           data: '{"version":"3.8","services":{"alpine":{"image":"alpine","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
-      - name: "Test Local Action"
-        id: test
+      - name: "Test Action Basic"
+        id: test1
         uses: ./
         with:
+          name: "test-stack"
+          file: "docker-compose.yaml"
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           #pass: ${{ secrets.DOCKER_PASS }}
           ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
-          file: "docker-compose.yaml"
+
+      - name: "Write YAML Private"
+        id: yaml-action
+        uses: teunmooij/yaml@v1
+        with:
+          data: '{"version":"3.8","services":{"alpine":{"image":"smashedr/alpine-private","command":"tail -f /dev/null"}}}'
+          to-file: "docker-compose.yaml"
+
+      - name: "Test Action Private"
+        id: test2
+        uses: ./
+        with:
           name: "test-stack"
+          file: "docker-compose.yaml"
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          #pass: ${{ secrets.DOCKER_PASS }}
+          ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
+          #registry_host: "ghcr.io"
+          registry_user: ${{ vars.DOCKER_HUB_USER }}
+          registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
 
   lint:
     name: "Lint"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  PRIVATE_IMAGE: "smashedr/alpine-private" # amd64/arm64
+  PRIVATE_IMAGE: "smashedr/alpine-private:latest" # amd64/arm64
 
 jobs:
   test:
@@ -22,7 +22,7 @@ jobs:
       - name: "Write YAML Basic"
         uses: teunmooij/yaml@v1
         with:
-          data: '{"version":"3.8","services":{"alpine":{"image":"alpine","command":"tail -f /dev/null"}}}'
+          data: '{"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
       - name: "Test Action Basic"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Write YAML Basic"
-        id: yaml-action
         uses: teunmooij/yaml@v1
         with:
           data: '{"version":"3.8","services":{"alpine":{"image":"alpine","command":"tail -f /dev/null"}}}'
@@ -36,7 +35,6 @@ jobs:
           ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
 
       - name: "Write YAML Private"
-        id: yaml-action
         uses: teunmooij/yaml@v1
         with:
           data: '{"version":"3.8","services":{"alpine":{"image":"smashedr/alpine-private","command":"tail -f /dev/null"}}}'

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,15 +4,15 @@
   "singleQuote": true,
   "overrides": [
     {
-      "files": ["**/*.json", "**/*.yaml", "**/*.yml"],
+      "files": ["**/*.html", "**/*.yaml", "**/*.yml"],
       "options": {
         "singleQuote": false
       }
     },
     {
-      "files": ["**/*.json", "**/*.yaml", "**/*.yml"],
+      "files": ["**/*.js", "**/*.css", "**/*.scss"],
       "options": {
-        "tabWidth": 2
+        "tabWidth": 4
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 # Docker Stack Deploy Action
 
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
+You can also optionally authenticate against a private registry using a username and password.
 
 For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
@@ -20,29 +21,34 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input    | required | default               | description               |
-| -------- | -------- | --------------------- | ------------------------- |
-| host     | **Yes**  | -                     | Remote Docker hostname    |
-| port     | No       | `22`                  | Remote Docker port        |
-| user     | **Yes**  | -                     | Remote Docker username    |
-| pass     | No       | -                     | Remote Docker password \* |
-| ssh_key  | No       | -                     | Remote SSH Key file \*    |
-| file     | No       | `docker-compose.yaml` | Docker Compose file       |
-| name     | **Yes**  | -                     | Docker Stack name         |
-| env_file | No       | -                     | Docker Environment file   |
+| input         | required | default               | description                     |
+| ------------- | -------- | --------------------- | ------------------------------- |
+| host          | **Yes**  | -                     | Remote Docker hostname          |
+| port          | No       | `22`                  | Remote Docker port              |
+| user          | **Yes**  | -                     | Remote Docker username          |
+| pass          | No       | -                     | Remote Docker password \*       |
+| ssh_key       | No       | -                     | Remote SSH Key file \*          |
+| file          | No       | `docker-compose.yaml` | Docker Compose file             |
+| name          | **Yes**  | -                     | Docker Stack name               |
+| env_file      | No       | -                     | Docker Environment file         |
+| registry_host | No       | -                     | Registry Authentication Host \* |
+| registry_user | No       | -                     | Registry Authentication User \* |
+| registry_pass | No       | -                     | Registry Authentication Pass \* |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`
+
+**registry_host/user/pass** - For private registries all of these values must be provided
 
 ```yaml
 - name: 'Docker Stack Deploy'
   uses: cssnr/stack-deploy-action@v1
   with:
+    name: 'stack-name'
+    file: 'docker-compose-swarm.yaml'
     host: ${{ secrets.DOCKER_HOST }}
     port: ${{ secrets.DOCKER_PORT }}
     user: ${{ secrets.DOCKER_USER }}
     pass: ${{ secrets.DOCKER_PASS }}
-    file: 'docker-compose-swarm.yaml'
-    name: 'stack-name'
 ```
 
 ## Examples
@@ -68,12 +74,29 @@ jobs:
       - name: 'Docker Stack Deploy'
         uses: cssnr/stack-deploy-action@v1
         with:
+          name: 'stack-name'
+          file: 'docker-compose-swarm.yaml'
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           pass: ${{ secrets.DOCKER_PASS }}
-          file: 'docker-compose-swarm.yaml'
-          name: 'stack-name'
+```
+
+With Private Registry Credentials
+
+```yaml
+- name: 'Docker Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    name: 'stack-name'
+    file: 'docker-compose-swarm.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    pass: ${{ secrets.DOCKER_PASS }}
+    registry_host: 'ghcr.io'
+    registry_user: ${{ vars.GHCR_USER }}
+    registry_pass: ${{ secrets.GHCR_PASS }}
 ```
 
 Full Example
@@ -115,14 +138,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: 'Docker Login'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: $${{ env.REGISTRY }}
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.GHCR_PASS }}
 
       - name: 'Build and Push'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -132,12 +155,12 @@ jobs:
       - name: 'Docker Stack Deploy'
         uses: cssnr/stack-deploy-action@v1
         with:
+          name: 'stack-name'
+          file: 'docker-compose-swarm.yaml'
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           ssh_key: '${{ secrets.DOCKER_SSH_KEY }}'
-          file: 'docker-compose-swarm.yaml'
-          name: 'stack-name'
 ```
 
 # Support

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 **registry_auth** - Set to `true` to deploy with `--with-registry-auth`
 
-**registry_host/user/pass** - Set to run `docker login` before stack deploy
+**registry_host** - To run `docker login` on another registry, ex: `ghcr.io`
+
+**registry_user/registry_pass** - Required to run `docker login` before stack deploy
 
 ```yaml
 - name: 'Docker Stack Deploy'

--- a/README.md
+++ b/README.md
@@ -21,23 +21,26 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input         | required | default               | description                     |
-| ------------- | -------- | --------------------- | ------------------------------- |
-| host          | **Yes**  | -                     | Remote Docker hostname          |
-| port          | No       | `22`                  | Remote Docker port              |
-| user          | **Yes**  | -                     | Remote Docker username          |
-| pass          | No       | -                     | Remote Docker password \*       |
-| ssh_key       | No       | -                     | Remote SSH Key file \*          |
-| file          | No       | `docker-compose.yaml` | Docker Compose file             |
-| name          | **Yes**  | -                     | Docker Stack name               |
-| env_file      | No       | -                     | Docker Environment file         |
-| registry_host | No       | -                     | Registry Authentication Host \* |
-| registry_user | No       | -                     | Registry Authentication User \* |
-| registry_pass | No       | -                     | Registry Authentication Pass \* |
+| input         | required | default               | description                       |
+| ------------- | -------- | --------------------- | --------------------------------- |
+| host          | **Yes**  | -                     | Remote Docker hostname            |
+| port          | No       | `22`                  | Remote Docker port                |
+| user          | **Yes**  | -                     | Remote Docker username            |
+| pass          | No       | -                     | Remote Docker password \*         |
+| ssh_key       | No       | -                     | Remote SSH Key file \*            |
+| file          | No       | `docker-compose.yaml` | Docker Compose file               |
+| name          | **Yes**  | -                     | Docker Stack name                 |
+| env_file      | No       | -                     | Docker Environment file           |
+| registry_auth | No       | -                     | Enable Registry Authentication \* |
+| registry_host | No       | -                     | Registry Authentication Host \*   |
+| registry_user | No       | -                     | Registry Authentication User \*   |
+| registry_pass | No       | -                     | Registry Authentication Pass \*   |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`
 
-**registry_host/user/pass** - For private registries all of these values must be provided
+**registry_auth** - Set to `true` to deploy with `--with-registry-auth`
+
+**registry_host/user/pass** - Set to run `docker login` before stack deploy
 
 ```yaml
 - name: 'Docker Stack Deploy'
@@ -49,6 +52,23 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
     port: ${{ secrets.DOCKER_PORT }}
     user: ${{ secrets.DOCKER_USER }}
     pass: ${{ secrets.DOCKER_PASS }}
+```
+
+Enable Registry Authentication and Perform Docker Login
+
+```yaml
+- name: 'Docker Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    name: 'stack-name'
+    file: 'docker-compose-swarm.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    pass: ${{ secrets.DOCKER_PASS }}
+    registry_host: 'ghcr.io'
+    registry_user: ${{ vars.GHCR_USER }}
+    registry_pass: ${{ secrets.GHCR_PASS }}
 ```
 
 ## Examples
@@ -80,23 +100,6 @@ jobs:
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           pass: ${{ secrets.DOCKER_PASS }}
-```
-
-With Private Registry Credentials
-
-```yaml
-- name: 'Docker Stack Deploy'
-  uses: cssnr/stack-deploy-action@v1
-  with:
-    name: 'stack-name'
-    file: 'docker-compose-swarm.yaml'
-    host: ${{ secrets.DOCKER_HOST }}
-    port: ${{ secrets.DOCKER_PORT }}
-    user: ${{ secrets.DOCKER_USER }}
-    pass: ${{ secrets.DOCKER_PASS }}
-    registry_host: 'ghcr.io'
-    registry_user: ${{ vars.GHCR_USER }}
-    registry_pass: ${{ secrets.GHCR_PASS }}
 ```
 
 Full Example

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can also optionally authenticate against a private registry using a username
 
 For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
+_Portainer Users_: You can deploy directly to Portainer with: [cssnr/portainer-stack-deploy-action](https://github.com/cssnr/portainer-stack-deploy-action)
+
 - [Inputs](#Inputs)
 - [Examples](#Examples)
 - [Support](#Support)
@@ -21,26 +23,26 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input         | required | default               | description                       |
-| ------------- | -------- | --------------------- | --------------------------------- |
-| host          | **Yes**  | -                     | Remote Docker hostname            |
-| port          | No       | `22`                  | Remote Docker port                |
-| user          | **Yes**  | -                     | Remote Docker username            |
-| pass          | No       | -                     | Remote Docker password \*         |
-| ssh_key       | No       | -                     | Remote SSH Key file \*            |
-| file          | No       | `docker-compose.yaml` | Docker Compose file               |
-| name          | **Yes**  | -                     | Docker Stack name                 |
-| env_file      | No       | -                     | Docker Environment file           |
-| registry_auth | No       | -                     | Enable Registry Authentication \* |
-| registry_host | No       | -                     | Registry Authentication Host \*   |
-| registry_user | No       | -                     | Registry Authentication User \*   |
-| registry_pass | No       | -                     | Registry Authentication Pass \*   |
+| input         | required         | default               | description                       |
+| ------------- | ---------------- | --------------------- | --------------------------------- |
+| host          | **Yes**          | -                     | Remote Docker hostname            |
+| port          | No               | `22`                  | Remote Docker port                |
+| user          | **Yes**          | -                     | Remote Docker username            |
+| pass          | Not w/ `ssh_key` | -                     | Remote Docker password \*         |
+| ssh_key       | Not w/ `pass`    | -                     | Remote SSH Key file \*            |
+| file          | No               | `docker-compose.yaml` | Docker Compose file               |
+| name          | **Yes**          | -                     | Docker Stack name                 |
+| env_file      | No               | -                     | Docker Environment file           |
+| registry_auth | No               | -                     | Enable Registry Authentication \* |
+| registry_host | No               | -                     | Registry Authentication Host \*   |
+| registry_user | No               | -                     | Registry Authentication User \*   |
+| registry_pass | No               | -                     | Registry Authentication Pass \*   |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`
 
 **registry_auth** - Set to `true` to deploy with `--with-registry-auth`
 
-**registry_host** - To run `docker login` on another registry, ex: `ghcr.io`
+**registry_host** - To run `docker login` on another registry, example: `ghcr.io`
 
 **registry_user/registry_pass** - Required to run `docker login` before stack deploy
 
@@ -56,7 +58,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
     pass: ${{ secrets.DOCKER_PASS }}
 ```
 
-Enable Registry Authentication and Perform Docker Login
+Use `docker login` and enable `--with-registry-auth`
 
 ```yaml
 - name: 'Docker Stack Deploy'

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Additionally, you can support other GitHub Actions I have published:
 - [Update JSON Value Action](https://github.com/cssnr/update-json-value-action)
 - [Parse Issue Form Action](https://github.com/cssnr/parse-issue-form-action)
 - [Mirror Repository Action](https://github.com/cssnr/mirror-repository-action)
+- [Stack Deploy Action](https://github.com/cssnr/stack-deploy-action)
 - [Portainer Stack Deploy](https://github.com/cssnr/portainer-stack-deploy-action)
 - [Mozilla Addon Update Action](https://github.com/cssnr/mozilla-addon-update-action)
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Docker Stack Deploy"
-description: "Deploy a Docker Stack"
+description: "Deploy a Docker Stack to a Remote Host over SSH"
 author: "Shane"
 branding:
   icon: "layers"
@@ -31,6 +31,15 @@ inputs:
     required: true
   env_file:
     description: "Environment File"
+    required: false
+  registry_host:
+    description: "Registry Auth Hostname"
+    required: false
+  registry_user:
+    description: "Registry Auth Username"
+    required: false
+  registry_pass:
+    description: "Registry Auth Password"
     required: false
 
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,9 @@ inputs:
   env_file:
     description: "Environment File"
     required: false
+  registry_auth:
+    description: "Enable Registry Auth"
+    required: false
   registry_host:
     description: "Registry Auth Hostname"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Docker Stack Deploy"
-description: "Deploy a Docker Stack to a Remote Host over SSH"
+description: "Deploy a Docker Stack to a Remote Host over SSH w/ Optional Registry Authentication"
 author: "Shane"
 branding:
   icon: "layers"

--- a/src/main.sh
+++ b/src/main.sh
@@ -51,7 +51,7 @@ docker context ls
 docker context use remote
 
 if [ -n "${INPUT_ENV_FILE}" ];then
-    echo -e "\u001b[36mSourcing Environment File: ${INPUT_ENV_FILE}"
+    echo -e "\u001b[36mSourcing Environment File: \u001b[37;1m${INPUT_ENV_FILE}"
     stat "${INPUT_ENV_FILE}"
     set -a
     # shellcheck disable=SC1090
@@ -60,5 +60,13 @@ if [ -n "${INPUT_ENV_FILE}" ];then
     # export ENV_FILE="${INPUT_ENV_FILE}"
 fi
 
+EXTRA_ARGS=""
+if [[ -n "${INPUT_REGISTRY_HOST}" && -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
+    echo -e "\u001b[36mAuthenticating with Registry: \u001b[37;1m${INPUT_REGISTRY_HOST}"
+    EXTRA_ARGS+=" --with-registry-auth "
+    echo "${INPUT_REGISTRY_PASS}" |
+        docker login --username "${INPUT_REGISTRY_USER}" --password-stdin "${INPUT_REGISTRY_HOST}"
+fi
+
 echo -e "\u001b[36mDeploying Stack: \u001b[37;1m${INPUT_NAME}"
-docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}"
+docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}" ${EXTRA_ARGS}

--- a/src/main.sh
+++ b/src/main.sh
@@ -46,9 +46,11 @@ trap cleanup_trap EXIT HUP INT QUIT PIPE TERM
 echo -e "\u001b[36mVerifying Docker and Setting Context."
 ssh -p "${INPUT_PORT}" "${INPUT_USER}@${INPUT_HOST}" "docker info" > /dev/null
 
-docker context create remote --docker "host=ssh://${INPUT_USER}@${INPUT_HOST}:${INPUT_PORT}"
-docker context ls
+if ! docker context inspect remote >/dev/null 2>&1;then
+    docker context create remote --docker "host=ssh://${INPUT_USER}@${INPUT_HOST}:${INPUT_PORT}"
+fi
 docker context use remote
+docker context ls
 
 if [ -n "${INPUT_ENV_FILE}" ];then
     echo -e "\u001b[36mSourcing Environment File: \u001b[37;1m${INPUT_ENV_FILE}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -60,12 +60,17 @@ if [ -n "${INPUT_ENV_FILE}" ];then
     # export ENV_FILE="${INPUT_ENV_FILE}"
 fi
 
-EXTRA_ARGS=()
 if [[ -n "${INPUT_REGISTRY_HOST}" && -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
-    echo -e "\u001b[36mAuthenticating with Registry: \u001b[37;1m${INPUT_REGISTRY_HOST}"
-    EXTRA_ARGS+=("--with-registry-auth")
+    echo -e "\u001b[36mLogging in to Registry: \u001b[37;1m${INPUT_REGISTRY_HOST}"
     echo "${INPUT_REGISTRY_PASS}" |
         docker login --username "${INPUT_REGISTRY_USER}" --password-stdin "${INPUT_REGISTRY_HOST}"
+    INPUT_REGISTRY_AUTH="true"
+fi
+
+EXTRA_ARGS=()
+if [[ -n "${INPUT_REGISTRY_AUTH}" ]];then
+    echo -e "Adding extra arg: --with-registry-auth"
+    EXTRA_ARGS+=("--with-registry-auth")
 fi
 
 echo -e "\u001b[36mDeploying Stack: \u001b[37;1m${INPUT_NAME}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -60,8 +60,8 @@ if [ -n "${INPUT_ENV_FILE}" ];then
     # export ENV_FILE="${INPUT_ENV_FILE}"
 fi
 
-if [[ -n "${INPUT_REGISTRY_HOST}" && -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
-    echo -e "\u001b[36mLogging in to Registry: \u001b[37;1m${INPUT_REGISTRY_HOST}"
+if [[ -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
+    echo -e "\u001b[36mLogging in to Registry: \u001b[37;1m${INPUT_REGISTRY_HOST:-Docker Hub}"
     echo "${INPUT_REGISTRY_PASS}" |
         docker login --username "${INPUT_REGISTRY_USER}" --password-stdin "${INPUT_REGISTRY_HOST}"
     INPUT_REGISTRY_AUTH="true"

--- a/src/main.sh
+++ b/src/main.sh
@@ -60,13 +60,13 @@ if [ -n "${INPUT_ENV_FILE}" ];then
     # export ENV_FILE="${INPUT_ENV_FILE}"
 fi
 
-EXTRA_ARGS=""
+EXTRA_ARGS=()
 if [[ -n "${INPUT_REGISTRY_HOST}" && -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
     echo -e "\u001b[36mAuthenticating with Registry: \u001b[37;1m${INPUT_REGISTRY_HOST}"
-    EXTRA_ARGS+=" --with-registry-auth "
+    EXTRA_ARGS+=("--with-registry-auth")
     echo "${INPUT_REGISTRY_PASS}" |
         docker login --username "${INPUT_REGISTRY_USER}" --password-stdin "${INPUT_REGISTRY_HOST}"
 fi
 
 echo -e "\u001b[36mDeploying Stack: \u001b[37;1m${INPUT_NAME}"
-docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}" ${EXTRA_ARGS}
+docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
# Overview

This PR optionally allows adding `--with-registry-auth` and `docker login` when deploying a stack and fixes a docker context bug.

1. If you need to perform `docker login` and enable `--with-registry-auth` add these options:
```yaml
registry_host: 'ghcr.io'  # optional
registry_user: ${{ vars.GHCR_USER }}
registry_pass: ${{ secrets.GHCR_PASS }}
```

2. If you do not need to log in, and only need to add `--with-registry-auth` just enable this option:
```yaml
registry_auth: true
```

3. This also fixes a bug when trying to run multiple stack deploy steps in a single job by checking if the remote context exists before creating it.

**I will let this bake to see if anyone has any comments or suggestions; however, this is ready to merge.**

### Further Improvements and Thoughts

If we need more functionality we can always add in these options in the future:
- Allow adding custom extra arguments to deploy command.
- Allow adding custom extra arguments to the ssh command.
- Allow adding custom post/pre command lists to be executed.

## Related

This combines and resolves the following PRs:
- https://github.com/cssnr/stack-deploy-action/pull/12
- https://github.com/cssnr/stack-deploy-action/pull/9
- https://github.com/cssnr/stack-deploy-action/pull/8

## TODO

- [x] Allow enabling `--with-registry-auth` without providing credentials.
- [x] Add a working test for registry authentication.
- [x] Make registry_host optional.
- [x] Enable workflows for PR's.
- [x] Bake for 8 hours on low.
