### PR TITLE
Add Stack Deploy Options

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
       #    cat "${GITHUB_EVENT_PATH}"
 
       - name: "ShellCheck"
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         uses: ludeeus/action-shellcheck@master
         env:
           SHELLCHECK_OPTS: -x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,14 +6,14 @@ on:
     - cron: "18 18 * * 1,3,5"
   push:
     branches: ["**"]
-    paths:
-      - "dist/**"
-      - "src/**"
-      - ".github/workflows/test.yaml"
-      - "Dockerfile"
-      - "package*.json"
-      - "requirements.txt"
-      - "action.yaml"
+    #paths:
+    #  - "dist/**"
+    #  - "src/**"
+    #  - ".github/workflows/test.yaml"
+    #  - "Dockerfile"
+    #  - "package*.json"
+    #  - "requirements.txt"
+    #  - "action.yaml"
 
 env:
   PRIVATE_IMAGE: ${{ vars.PRIVATE_IMAGE || 'smashedr/alpine-private:latest' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,8 +40,9 @@ jobs:
         if: ${{ !cancelled() }}
         uses: teunmooij/yaml@v1
         with:
-          data: '{"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
 
       - name: "1: Test Password"
         if: ${{ !cancelled() }}
@@ -61,8 +62,9 @@ jobs:
         if: ${{ !cancelled() && !github.event.act }}
         uses: teunmooij/yaml@v1
         with:
-          data: '{"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
 
       - name: "2: Test SSH and Auth"
         if: ${{ !cancelled() && !github.event.act }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,8 @@ jobs:
           user: ${{ secrets.DOCKER_USER }}
           pass: ${{ secrets.DOCKER_PASS }}
           #ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
+          detach: false
+          resolve_image: "changed"
 
       - name: "2: Write YAML"
         if: ${{ always() && !github.event.act }}
@@ -73,6 +75,7 @@ jobs:
           user: ${{ secrets.DOCKER_USER }}
           #pass: ${{ secrets.DOCKER_PASS }}
           ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
+          prune: true
           registry_user: ${{ vars.DOCKER_HUB_USER }}
           registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
           summary: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: test
+      group: ${{ github.workflow }}
       cancel-in-progress: true
 
     steps:
@@ -37,14 +37,14 @@ jobs:
       #    cat "${GITHUB_EVENT_PATH}"
 
       - name: "1: Write YAML"
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         uses: teunmooij/yaml@v1
         with:
           data: '{"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
       - name: "1: Test Password"
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         uses: ./
         with:
           name: test_stack-deploy
@@ -53,19 +53,19 @@ jobs:
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           pass: ${{ secrets.DOCKER_PASS }}
-          #ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
+          #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
           detach: false
           resolve_image: "changed"
 
       - name: "2: Write YAML"
-        if: ${{ always() && !github.event.act }}
+        if: ${{ !cancelled() && !github.event.act }}
         uses: teunmooij/yaml@v1
         with:
           data: '{"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}'
           to-file: "docker-compose.yaml"
 
       - name: "2: Test SSH and Auth"
-        if: ${{ always() && !github.event.act }}
+        if: ${{ !cancelled() && !github.event.act }}
         uses: ./
         with:
           name: test_stack-deploy
@@ -74,7 +74,7 @@ jobs:
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           #pass: ${{ secrets.DOCKER_PASS }}
-          ssh_key: "${{ secrets.DOCKER_SSH_KEY }}"
+          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
           prune: true
           registry_user: ${{ vars.DOCKER_HUB_USER }}
           registry_pass: ${{ secrets.DOCKER_HUB_PASS }}

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 
 ## Examples
 
-Use password, `docker login` and enable `--with-registry-auth`
+💡 _Click on a heading to expand or collapse the examples._
+
+<details open><summary>Use password, `docker login` and enable `--with-registry-auth`</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -139,7 +141,9 @@ Use password, `docker login` and enable `--with-registry-auth`
     registry_pass: ${{ secrets.GHCR_PASS }}
 ```
 
-Use SSH key, prune services, set `--detach=false` and `--resolve-image=changed`
+</details>
+
+<details><summary>Use SSH key, prune services, set `--detach=false` and `--resolve-image=changed`</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -156,7 +160,9 @@ Use SSH key, prune services, set `--detach=false` and `--resolve-image=changed`
     resolve_image: changed
 ```
 
-Simple Workflow Example
+</details>
+
+<details><summary>Simple workflow example</summary>
 
 ```yaml
 name: 'Stack Deploy Action'
@@ -185,7 +191,9 @@ jobs:
           pass: ${{ secrets.DOCKER_PASS }}
 ```
 
-Full Workflow Example
+</details>
+
+<details><summary>Full workflow example</summary>
 
 ```yaml
 name: 'Stack Deploy Action'
@@ -261,6 +269,8 @@ jobs:
           user: ${{ secrets.DOCKER_USER }}
           ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
 ```
+
+</details>
 
 For more examples, you can check out other projects using this action:  
 https://github.com/cssnr/stack-deploy-action/network/dependents

--- a/README.md
+++ b/README.md
@@ -30,23 +30,28 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input         |   required   | default               | description                       |
-| ------------- | :----------: | --------------------- | --------------------------------- |
-| host          |   **Yes**    | -                     | Remote Docker hostname            |
-| port          |      -       | `22`                  | Remote Docker port                |
-| user          |   **Yes**    | -                     | Remote Docker username            |
-| pass          | or `ssh_key` | -                     | Remote Docker password \*         |
-| ssh_key       |  or `pass`   | -                     | Remote SSH Key file \*            |
-| name          |   **Yes**    | -                     | Docker Stack name                 |
-| file          |      -       | `docker-compose.yaml` | Docker Compose file               |
-| env_file      |      -       | -                     | Docker Environment file           |
-| registry_auth |      -       | -                     | Enable Registry Authentication \* |
-| registry_host |      -       | -                     | Registry Authentication Host \*   |
-| registry_user |      -       | -                     | Registry Authentication User \*   |
-| registry_pass |      -       | -                     | Registry Authentication Pass \*   |
-| summary       |      -       | `true`                | Add Job Summary \*                |
+| input         |   required   | default               | description                        |
+| ------------- | :----------: | --------------------- | ---------------------------------- |
+| host          |   **Yes**    | -                     | Remote Docker hostname             |
+| port          |      -       | `22`                  | Remote Docker port                 |
+| user          |   **Yes**    | -                     | Remote Docker username             |
+| pass          | or `ssh_key` | -                     | Remote Docker password \*          |
+| ssh_key       |  or `pass`   | -                     | Remote SSH Key file \*             |
+| name          |   **Yes**    | -                     | Docker Stack name                  |
+| file          |      -       | `docker-compose.yaml` | Docker Compose file                |
+| env_file      |      -       | -                     | Docker Environment file            |
+| detach        |      -       | `true`                | Detach flag, `false` to disable \* |
+| prune         |      -       | `false`               | Prune flag, `true` to enable       |
+| resolve_image |      -       | `always`              | [`always`, `changed`, `never`]     |
+| registry_auth |      -       | -                     | Enable Registry Authentication \*  |
+| registry_host |      -       | -                     | Registry Authentication Host \*    |
+| registry_user |      -       | -                     | Registry Authentication User \*    |
+| registry_pass |      -       | -                     | Registry Authentication Pass \*    |
+| summary       |      -       | `true`                | Add Job Summary \*                 |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`.
+
+**detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 
 **registry_auth** - Set to `true` to deploy with `--with-registry-auth`.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To use a docker `env_file` specify it in your compose file and make it available
 If you need compose file templating this can also be done in a previous step.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
+This will generate extra output in the logs and is useful for debugging deployments.
 
 **resolve_image** - When the default `always` is used, this argument is omitted.
 
@@ -81,7 +82,9 @@ To view a workflow run, click on a recent
 
 🎉 Stack `test_stack-deploy` Successfully Deployed.
 
-`docker stack deploy --detach=false --resolve-image=changed -c docker-compose.yaml test_stack-deploy`
+```text
+docker stack deploy --detach=false --resolve-image=changed -c docker-compose.yaml test_stack-deploy
+```
 
 <details><summary>Results</summary>
 

--- a/README.md
+++ b/README.md
@@ -33,34 +33,36 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input         |   required   | default               | description                              |
-| ------------- | :----------: | --------------------- | ---------------------------------------- |
-| name          |   **Yes**    | -                     | Docker Stack name                        |
-| file          |      -       | `docker-compose.yaml` | Docker Compose file                      |
-| host          |   **Yes**    | -                     | Remote Docker hostname                   |
-| port          |      -       | `22`                  | Remote Docker port                       |
-| user          |   **Yes**    | -                     | Remote Docker username                   |
-| pass          | or `ssh_key` | -                     | Remote Docker password \*                |
-| ssh_key       |  or `pass`   | -                     | Remote SSH Key file \*                   |
-| env_file      |      -       | -                     | Docker Environment file \*               |
-| detach        |      -       | `true`                | Detach flag, `false` to disable \*       |
-| prune         |      -       | `false`               | Prune flag, `true` to enable             |
-| resolve_image |      -       | `always`              | One of [`always`, `changed`, `never`] \* |
-| registry_auth |      -       | -                     | Enable Registry Authentication \*        |
-| registry_host |      -       | -                     | Registry Authentication Host \*          |
-| registry_user |      -       | -                     | Registry Authentication User \*          |
-| registry_pass |      -       | -                     | Registry Authentication Pass \*          |
-| summary       |      -       | `true`                | Add Job Summary \*                       |
+| input         |   required   | default               | description                               |
+| ------------- | :----------: | --------------------- | ----------------------------------------- |
+| name          |   **Yes**    | -                     | Docker Stack Name                         |
+| file          |      -       | `docker-compose.yaml` | Docker Compose File                       |
+| host          |   **Yes**    | -                     | Remote Docker Hostname                    |
+| port          |      -       | `22`                  | Remote Docker Port                        |
+| user          |   **Yes**    | -                     | Remote Docker Username                    |
+| pass          | or `ssh_key` | -                     | Remote Docker Password \*                 |
+| ssh_key       |  or `pass`   | -                     | Remote SSH Key File \*                    |
+| env_file      |      -       | -                     | Docker Environment File \*                |
+| detach        |      -       | `true`                | Detach Flag, `false` to disable \*        |
+| prune         |      -       | `false`               | Prune Flag, `true` to enable              |
+| resolve_image |      -       | `always`              | Options [`always`, `changed`, `never`] \* |
+| registry_auth |      -       | -                     | Enable Registry Authentication \*         |
+| registry_host |      -       | -                     | Registry Authentication Host \*           |
+| registry_user |      -       | -                     | Registry Authentication Username \*       |
+| registry_pass |      -       | -                     | Registry Authentication Password \*       |
+| summary       |      -       | `true`                | Add Job Summary \*                        |
+
+For additional details on inputs, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`.
 
-**env_file** - Variables in this file are exported before stack deploy.  
-To use a docker `env_file` specify it in your compose file and download it in a step before this step.
+**env_file** - Variables in this file are exported before running stack deploy.
+To use a docker `env_file` specify it in your compose file and make it available in a previous step.
+If you need compose file templating this can also be done in a previous step.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 
 **resolve_image** - When the default `always` is used, this argument is omitted.
-For more information see the [docs](https://docs.docker.com/reference/cli/docker/stack/deploy/).
 
 **registry_auth** - Set to `true` to deploy with `--with-registry-auth`.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/cssnr/stack-deploy-action?logo=github&logoColor=white&label=updated)](https://github.com/cssnr/stack-deploy-action/graphs/commit-activity)
 [![Codeberg Last Commit](https://img.shields.io/gitea/last-commit/cssnr/stack-deploy-action/master?gitea_url=https%3A%2F%2Fcodeberg.org%2F&logo=codeberg&logoColor=white&label=updated)](https://codeberg.org/cssnr/stack-deploy-action)
 [![GitHub Top Language](https://img.shields.io/github/languages/top/cssnr/stack-deploy-action?logo=htmx&logoColor=white)](https://github.com/cssnr/stack-deploy-action)
+[![GitHub Discussions](https://img.shields.io/github/discussions/cssnr/stack-deploy-action)](https://github.com/cssnr/stack-deploy-action/discussions)
 [![GitHub Forks](https://img.shields.io/github/forks/cssnr/stack-deploy-action?style=flat&logo=github)](https://github.com/cssnr/stack-deploy-action/forks)
 [![GitHub Repo Stars](https://img.shields.io/github/stars/cssnr/stack-deploy-action?style=flat&logo=github&logoColor=white)](https://github.com/cssnr/stack-deploy-action/stargazers)
 [![GitHub Org Stars](https://img.shields.io/github/stars/cssnr?style=flat&logo=github&logoColor=white&label=org%20stars)](https://cssnr.github.io/)
@@ -64,6 +65,9 @@ For more information see the [docs](https://docs.docker.com/reference/cli/docker
 
 **summary** - Write a Summary for the job. To disable this set to `false`.
 
+To view a workflow run, click on a recent
+[Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
+
 <details><summary>👀 View Example Job Summary</summary>
 
 ---
@@ -81,9 +85,6 @@ Updating service test-stack_alpine (id: ewi9ck5hcdmmvaj8ms0te4t8r)
 ---
 
 </details>
-
-To view a workflow run, click on a recent
-[Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 
 ```yaml
 - name: 'Stack Deploy'
@@ -219,7 +220,7 @@ jobs:
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
-          ssh_key: '${{ secrets.DOCKER_SSH_KEY }}'
+          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
 ```
 
 # Support

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
 You can also optionally authenticate against a private registry using a username and password.
 
+This action uses a remote docker context to deploy the stack from the working directory allowing you to easily prepare the workspace for deployment.
+
 For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 **Portainer Users:** You can deploy directly to Portainer with: [cssnr/portainer-stack-deploy-action](https://github.com/cssnr/portainer-stack-deploy-action)
@@ -33,14 +35,14 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 | input         |   required   | default               | description                              |
 | ------------- | :----------: | --------------------- | ---------------------------------------- |
+| name          |   **Yes**    | -                     | Docker Stack name                        |
+| file          |      -       | `docker-compose.yaml` | Docker Compose file                      |
 | host          |   **Yes**    | -                     | Remote Docker hostname                   |
 | port          |      -       | `22`                  | Remote Docker port                       |
 | user          |   **Yes**    | -                     | Remote Docker username                   |
 | pass          | or `ssh_key` | -                     | Remote Docker password \*                |
 | ssh_key       |  or `pass`   | -                     | Remote SSH Key file \*                   |
-| name          |   **Yes**    | -                     | Docker Stack name                        |
-| file          |      -       | `docker-compose.yaml` | Docker Compose file                      |
-| env_file      |      -       | -                     | Docker Environment file                  |
+| env_file      |      -       | -                     | Docker Environment file \*               |
 | detach        |      -       | `true`                | Detach flag, `false` to disable \*       |
 | prune         |      -       | `false`               | Prune flag, `true` to enable             |
 | resolve_image |      -       | `always`              | One of [`always`, `changed`, `never`] \* |
@@ -51,6 +53,9 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | summary       |      -       | `true`                | Add Job Summary \*                       |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`.
+
+**env_file** - Variables in this file are exported before stack deploy.  
+To use a docker `env_file` specify it in your compose file and download it in a step before this step.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 
@@ -72,12 +77,23 @@ To view a workflow run, click on a recent
 
 ---
 
-🎉 Stack `test-stack` Successfully Deployed.
+🎉 Stack `test_stack-deploy` Successfully Deployed.
+
+`docker stack deploy --detach=false --resolve-image=changed -c docker-compose.yaml test_stack-deploy`
 
 <details><summary>Results</summary>
 
 ```text
-Updating service test-stack_alpine (id: ewi9ck5hcdmmvaj8ms0te4t8r)
+Updating service test_stack-deploy_alpine (id: tdk8v42m0rvp9hz4rbfrtszb6)
+1/1:
+overall progress: 0 out of 1 tasks
+overall progress: 1 out of 1 tasks
+verify: Waiting 5 seconds to verify that tasks are stable...
+verify: Waiting 4 seconds to verify that tasks are stable...
+verify: Waiting 3 seconds to verify that tasks are stable...
+verify: Waiting 2 seconds to verify that tasks are stable...
+verify: Waiting 1 seconds to verify that tasks are stable...
+verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -95,10 +95,13 @@ Updating service test-stack_alpine (id: ewi9ck5hcdmmvaj8ms0te4t8r)
     host: ${{ secrets.DOCKER_HOST }}
     port: ${{ secrets.DOCKER_PORT }}
     user: ${{ secrets.DOCKER_USER }}
-    pass: ${{ secrets.DOCKER_PASS }}
+    pass: ${{ secrets.DOCKER_PASS }} # not needed with ssh_key
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }} # not needed with pass
 ```
 
-Use `docker login` and enable `--with-registry-auth`
+## Examples
+
+Use password, `docker login` and enable `--with-registry-auth`
 
 ```yaml
 - name: 'Stack Deploy'
@@ -115,9 +118,24 @@ Use `docker login` and enable `--with-registry-auth`
     registry_pass: ${{ secrets.GHCR_PASS }}
 ```
 
-## Examples
+Use SSH key, prune services, set `--detach=false` and `--resolve-image=changed`
 
-Simple Example
+```yaml
+- name: 'Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    name: 'stack-name'
+    file: 'docker-compose-swarm.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+    detach: false
+    prune: true
+    resolve_image: changed
+```
+
+Simple Workflow Example
 
 ```yaml
 name: 'Stack Deploy Action'
@@ -146,7 +164,7 @@ jobs:
           pass: ${{ secrets.DOCKER_PASS }}
 ```
 
-Full Example
+Full Workflow Example
 
 ```yaml
 name: 'Stack Deploy Action'
@@ -222,6 +240,9 @@ jobs:
           user: ${{ secrets.DOCKER_USER }}
           ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
 ```
+
+For more examples, you can check out other projects using this action:  
+https://github.com/cssnr/stack-deploy-action/network/dependents
 
 # Support
 

--- a/README.md
+++ b/README.md
@@ -30,28 +30,31 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input         |   required   | default               | description                        |
-| ------------- | :----------: | --------------------- | ---------------------------------- |
-| host          |   **Yes**    | -                     | Remote Docker hostname             |
-| port          |      -       | `22`                  | Remote Docker port                 |
-| user          |   **Yes**    | -                     | Remote Docker username             |
-| pass          | or `ssh_key` | -                     | Remote Docker password \*          |
-| ssh_key       |  or `pass`   | -                     | Remote SSH Key file \*             |
-| name          |   **Yes**    | -                     | Docker Stack name                  |
-| file          |      -       | `docker-compose.yaml` | Docker Compose file                |
-| env_file      |      -       | -                     | Docker Environment file            |
-| detach        |      -       | `true`                | Detach flag, `false` to disable \* |
-| prune         |      -       | `false`               | Prune flag, `true` to enable       |
-| resolve_image |      -       | `always`              | [`always`, `changed`, `never`]     |
-| registry_auth |      -       | -                     | Enable Registry Authentication \*  |
-| registry_host |      -       | -                     | Registry Authentication Host \*    |
-| registry_user |      -       | -                     | Registry Authentication User \*    |
-| registry_pass |      -       | -                     | Registry Authentication Pass \*    |
-| summary       |      -       | `true`                | Add Job Summary \*                 |
+| input         |   required   | default               | description                              |
+| ------------- | :----------: | --------------------- | ---------------------------------------- |
+| host          |   **Yes**    | -                     | Remote Docker hostname                   |
+| port          |      -       | `22`                  | Remote Docker port                       |
+| user          |   **Yes**    | -                     | Remote Docker username                   |
+| pass          | or `ssh_key` | -                     | Remote Docker password \*                |
+| ssh_key       |  or `pass`   | -                     | Remote SSH Key file \*                   |
+| name          |   **Yes**    | -                     | Docker Stack name                        |
+| file          |      -       | `docker-compose.yaml` | Docker Compose file                      |
+| env_file      |      -       | -                     | Docker Environment file                  |
+| detach        |      -       | `true`                | Detach flag, `false` to disable \*       |
+| prune         |      -       | `false`               | Prune flag, `true` to enable             |
+| resolve_image |      -       | `always`              | One of [`always`, `changed`, `never`] \* |
+| registry_auth |      -       | -                     | Enable Registry Authentication \*        |
+| registry_host |      -       | -                     | Registry Authentication Host \*          |
+| registry_user |      -       | -                     | Registry Authentication User \*          |
+| registry_pass |      -       | -                     | Registry Authentication Pass \*          |
+| summary       |      -       | `true`                | Add Job Summary \*                       |
 
 **pass/ssh_key** - You must provide either a `pass` or `ssh_key`.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
+
+**resolve_image** - When the default `always` is used, this argument is omitted.
+For more information see the [docs](https://docs.docker.com/reference/cli/docker/stack/deploy/).
 
 **registry_auth** - Set to `true` to deploy with `--with-registry-auth`.
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 
 ## Examples
 
-💡 _Click on a heading to expand or collapse the examples._
+💡 _Click on a heading to expand or collapse an example._
 
-<details open><summary>Use password, `docker login` and enable `--with-registry-auth`</summary>
+<details open><summary>With password, docker login and --with-registry-auth</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -136,14 +136,14 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
     port: ${{ secrets.DOCKER_PORT }}
     user: ${{ secrets.DOCKER_USER }}
     pass: ${{ secrets.DOCKER_PASS }}
-    registry_host: 'ghcr.io'
+    registry_host: ghcr.io
     registry_user: ${{ vars.GHCR_USER }}
     registry_pass: ${{ secrets.GHCR_PASS }}
 ```
 
 </details>
 
-<details><summary>Use SSH key, prune services, set `--detach=false` and `--resolve-image=changed`</summary>
+<details><summary>With SSH key, --prune, --detach=false and --resolve-image=changed</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -162,7 +162,33 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 
 </details>
 
-<details><summary>Simple workflow example</summary>
+<details open><summary>With all inputs</summary>
+
+```yaml
+- name: 'Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    name: 'stack-name'
+    file: 'docker-compose-swarm.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    pass: ${{ secrets.DOCKER_PASS }} # not needed with ssh_key
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }} # not needed with pass
+    env_file: stack.env
+    detach: true
+    prune: false
+    resolve_image: always
+    registry_auth: true # not needed with registry_pass/registry_user
+    registry_host: ghcr.io
+    registry_user: ${{ vars.GHCR_USER }}
+    registry_pass: ${{ secrets.GHCR_PASS }}
+    summary: true
+```
+
+</details>
+
+<details><summary>Simple Workflow Example</summary>
 
 ```yaml
 name: 'Stack Deploy Action'
@@ -193,7 +219,7 @@ jobs:
 
 </details>
 
-<details><summary>Full workflow example</summary>
+<details><summary>Full Workflow Example</summary>
 
 ```yaml
 name: 'Stack Deploy Action'

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
     port: ${{ secrets.DOCKER_PORT }}
     user: ${{ secrets.DOCKER_USER }}
     pass: ${{ secrets.DOCKER_PASS }}
-    registry_host: ghcr.io
+    registry_host: 'ghcr.io'
     registry_user: ${{ vars.GHCR_USER }}
     registry_pass: ${{ secrets.GHCR_PASS }}
 ```
@@ -157,12 +157,12 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
     ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
     detach: false
     prune: true
-    resolve_image: changed
+    resolve_image: 'changed'
 ```
 
 </details>
 
-<details open><summary>With all inputs</summary>
+<details><summary>With All Inputs</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -175,12 +175,12 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
     user: ${{ secrets.DOCKER_USER }}
     pass: ${{ secrets.DOCKER_PASS }} # not needed with ssh_key
     ssh_key: ${{ secrets.DOCKER_SSH_KEY }} # not needed with pass
-    env_file: stack.env
+    env_file: 'stack.env'
     detach: true
     prune: false
-    resolve_image: always
+    resolve_image: 'always'
     registry_auth: true # not needed with registry_pass/registry_user
-    registry_host: ghcr.io
+    registry_host: 'ghcr.io'
     registry_user: ${{ vars.GHCR_USER }}
     registry_pass: ${{ secrets.GHCR_PASS }}
     summary: true
@@ -235,11 +235,15 @@ on:
 env:
   REGISTRY: 'ghcr.io'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build:
   name: 'Build'
   runs-on: ubuntu-latest
-  timeout-minutes: 5
+  timeout-minutes: 15
   permissions:
     packages: write
 
@@ -250,7 +254,7 @@ jobs:
     - name: 'Setup Buildx'
       uses: docker/setup-buildx-action@v2
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: 'linux/amd64,linux/arm64'
 
     - name: 'Docker Login'
       uses: docker/login-action@v3
@@ -263,14 +267,14 @@ jobs:
       id: tags
       uses: smashedr/docker-tags-action@v1
       with:
-        images: '$${{ env.REGISTRY }}/${{ github.repository }}'
+        images: $${{ env.REGISTRY }}/${{ github.repository }}
         tags: ${{ inputs.tags }}
 
     - name: 'Build and Push'
       uses: docker/build-push-action@v6
       with:
         context: .
-        platforms: linux/amd64,linux/arm64
+        platforms: 'linux/amd64,linux/arm64'
         push: true
         tags: ${{ steps.tags.outputs.tags }}
         labels: ${{ steps.tags.outputs.labels }}
@@ -294,6 +298,22 @@ jobs:
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
           ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+
+  cleanup:
+    name: 'Cleanup'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: deploy
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: 'Purge Cache'
+        uses: cssnr/cloudflare-purge-cache-action@v2
+        with:
+          token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          zones: cssnr.com
 ```
 
 </details>

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,18 @@ inputs:
   env_file:
     description: "Environment File"
     required: false
+  detach:
+    description: "Detach Flag"
+    required: false
+    default: "true"
+  prune:
+    description: "Prune Flag"
+    required: false
+    default: "false"
+  resolve_image:
+    description: "Resolve Image Flag"
+    required: false
+    default: "always"
   registry_auth:
     description: "Enable Registry Auth"
     required: false

--- a/src/main.sh
+++ b/src/main.sh
@@ -92,6 +92,9 @@ if [[ "${INPUT_PRUNE}" != "false" ]];then
     EXTRA_ARGS+=("--prune")
 fi
 if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
+    if [[ "${INPUT_RESOLVE_IMAGE}" != "changed" ]] && [[ "${INPUT_RESOLVE_IMAGE}" != "never" ]];then
+        echo "::error::Input resolve_image must be one of: always, changed, never"
+    fi
     echo -e "Adding: --resolve-image=${INPUT_RESOLVE_IMAGE}"
     EXTRA_ARGS+=("--resolve-image=${INPUT_RESOLVE_IMAGE}")
 fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -97,13 +97,11 @@ if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
         EXTRA_ARGS+=("--resolve-image=${INPUT_RESOLVE_IMAGE}")
     else
         echo "::error::Input resolve_image must be one of: always, changed, never"
-        exit 1
     fi
 fi
 
 echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
-echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}"
-echo -e "\u001b[33;1m--"
+echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" "\n"
 exec 5>&1
 # shellcheck disable=SC2034
 STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" | tee >(cat ->&5))

--- a/src/main.sh
+++ b/src/main.sh
@@ -6,7 +6,7 @@ set -e
 function cleanup_trap() {
     _ST="$?"
     if [ -z "${INPUT_SSH_KEY}" ];then
-        echo -e "🧹 Cleaning Up authorized_keys"
+        echo "🧹 Cleaning Up authorized_keys"
         ssh -o BatchMode=yes -o ConnectTimeout=30 -p "${INPUT_PORT}" "${INPUT_USER}@${INPUT_HOST}" \
             "sed -i '/docker-stack-deploy-action/d' ~/.ssh/authorized_keys"
     fi
@@ -21,7 +21,7 @@ function cleanup_trap() {
 
 SSH_DIR="/root/.ssh"
 
-echo "::group::Starting Stack Deploy Action"
+echo "::group::Starting Stack Deploy Action ${GITHUB_ACTION_REF}"
 echo "User: $(whoami)"
 echo "Script: ${0}"
 echo "Current Directory: $(pwd)"
@@ -33,7 +33,7 @@ ssh-keyscan -p "${INPUT_PORT}" -H "${INPUT_HOST}" >> "${SSH_DIR}/known_hosts"
 echo "::endgroup::"
 
 if [ -z "${INPUT_SSH_KEY}" ];then
-    echo -e "::group::Copying SSH Key to Remote Host"
+    echo "::group::Copying SSH Key to Remote Host"
     ssh-keygen -q -f "${SSH_DIR}/id_rsa" -N "" -C "docker-stack-deploy-action"
     eval "$(ssh-agent -s)"
     ssh-add "${SSH_DIR}/id_rsa"
@@ -80,28 +80,30 @@ fi
 
 EXTRA_ARGS=()
 if [[ -n "${INPUT_REGISTRY_AUTH}" ]];then
-    #echo -e "Adding: --with-registry-auth"
+    echo "::debug::Adding: --with-registry-auth"
     EXTRA_ARGS+=("--with-registry-auth")
 fi
 if [[ "${INPUT_DETACH}" != "true" ]];then
-    #echo -e "Adding: --detach=false"
+    echo "::debug::Adding: --detach=false"
     EXTRA_ARGS+=("--detach=false")
 fi
 if [[ "${INPUT_PRUNE}" != "false" ]];then
-    #echo -e "Adding: --prune"
+    echo "::debug::Adding: --prune"
     EXTRA_ARGS+=("--prune")
 fi
 if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
-    if [[ "${INPUT_RESOLVE_IMAGE}" != "changed" ]] && [[ "${INPUT_RESOLVE_IMAGE}" != "never" ]];then
+    if [[ "${INPUT_RESOLVE_IMAGE}" == "changed" || "${INPUT_RESOLVE_IMAGE}" == "never" ]];then
+        echo "::debug::Adding: --resolve-image=${INPUT_RESOLVE_IMAGE}"
+        EXTRA_ARGS+=("--resolve-image=${INPUT_RESOLVE_IMAGE}")
+    else
         echo "::error::Input resolve_image must be one of: always, changed, never"
         exit 1
     fi
-    #echo -e "Adding: --resolve-image=${INPUT_RESOLVE_IMAGE}"
-    EXTRA_ARGS+=("--resolve-image=${INPUT_RESOLVE_IMAGE}")
 fi
 
 echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
-echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" "\n--"
+echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}"
+echo -e "\u001b[33;1m\n--"
 exec 5>&1
 # shellcheck disable=SC2034
 STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" | tee >(cat ->&5))

--- a/src/main.sh
+++ b/src/main.sh
@@ -103,7 +103,7 @@ fi
 
 echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}"
-echo -e "\u001b[33;1m\n--"
+echo -e "\u001b[33;1m--"
 exec 5>&1
 # shellcheck disable=SC2034
 STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" | tee >(cat ->&5))

--- a/src/main.sh
+++ b/src/main.sh
@@ -78,14 +78,27 @@ if [[ -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
     echo "::endgroup::"
 fi
 
-echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
 EXTRA_ARGS=()
 if [[ -n "${INPUT_REGISTRY_AUTH}" ]];then
     echo -e "Adding: --with-registry-auth"
     EXTRA_ARGS+=("--with-registry-auth")
 fi
+if [[ "${INPUT_DETACH}" != "true" ]];then
+    echo -e "Adding: --detach=false"
+    EXTRA_ARGS+=("--detach=false")
+fi
+if [[ "${INPUT_PRUNE}" != "false" ]];then
+    echo -e "Adding: --prune"
+    EXTRA_ARGS+=("--prune")
+fi
+if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
+    echo -e "Adding: --resolve-image=${INPUT_RESOLVE_IMAGE}"
+    EXTRA_ARGS+=("--resolve-image=${INPUT_RESOLVE_IMAGE}")
+fi
+
+echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
 # shellcheck disable=SC2034
-STACK_RESULTS=$(docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}" "${EXTRA_ARGS[@]}")
+STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}")
 echo "::endgroup::"
 
 echo "${STACK_RESULTS}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -80,31 +80,33 @@ fi
 
 EXTRA_ARGS=()
 if [[ -n "${INPUT_REGISTRY_AUTH}" ]];then
-    echo -e "Adding: --with-registry-auth"
+    #echo -e "Adding: --with-registry-auth"
     EXTRA_ARGS+=("--with-registry-auth")
 fi
 if [[ "${INPUT_DETACH}" != "true" ]];then
-    echo -e "Adding: --detach=false"
+    #echo -e "Adding: --detach=false"
     EXTRA_ARGS+=("--detach=false")
 fi
 if [[ "${INPUT_PRUNE}" != "false" ]];then
-    echo -e "Adding: --prune"
+    #echo -e "Adding: --prune"
     EXTRA_ARGS+=("--prune")
 fi
 if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
     if [[ "${INPUT_RESOLVE_IMAGE}" != "changed" ]] && [[ "${INPUT_RESOLVE_IMAGE}" != "never" ]];then
         echo "::error::Input resolve_image must be one of: always, changed, never"
+        exit 1
     fi
-    echo -e "Adding: --resolve-image=${INPUT_RESOLVE_IMAGE}"
+    #echo -e "Adding: --resolve-image=${INPUT_RESOLVE_IMAGE}"
     EXTRA_ARGS+=("--resolve-image=${INPUT_RESOLVE_IMAGE}")
 fi
 
 echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
+echo docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}"
+exec 5>&1
 # shellcheck disable=SC2034
-STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}")
+STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" | tee >(cat ->&5))
+#echo "${STACK_RESULTS}"
 echo "::endgroup::"
-
-echo "${STACK_RESULTS}"
 
 if [[ "${INPUT_SUMMARY}" == "true" ]];then
     echo "📝 Writing Job Summary"

--- a/src/main.sh
+++ b/src/main.sh
@@ -101,11 +101,10 @@ if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
 fi
 
 echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
-echo docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}"
+echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" "\n--"
 exec 5>&1
 # shellcheck disable=SC2034
 STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" | tee >(cat ->&5))
-#echo "${STACK_RESULTS}"
 echo "::endgroup::"
 
 if [[ "${INPUT_SUMMARY}" == "true" ]];then

--- a/src/main.sh
+++ b/src/main.sh
@@ -101,10 +101,12 @@ if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
 fi
 
 echo -e "::group::Deploying Stack: \u001b[36;1m${INPUT_NAME}"
-echo -e "\u001b[33;1m"docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" "\n"
+COMMAND=("docker" "stack" "deploy" "${EXTRA_ARGS[@]}" "-c" "${INPUT_FILE}" "${INPUT_NAME}")
+echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034
-STACK_RESULTS=$(docker stack deploy "${EXTRA_ARGS[@]}" -c "${INPUT_FILE}" "${INPUT_NAME}" | tee >(cat ->&5))
+STACK_RESULTS=$("${COMMAND[@]}" | tee >(cat >&5))
+
 echo "::endgroup::"
 
 if [[ "${INPUT_SUMMARY}" == "true" ]];then

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -5,6 +5,8 @@ cat << EOM
 
 🎉 Stack \`${INPUT_NAME}\` Successfully Deployed.
 
+\`${COMMAND[*]}\`
+
 <details><summary>Results</summary>
 
 \`\`\`text

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -5,7 +5,9 @@ cat << EOM
 
 🎉 Stack \`${INPUT_NAME}\` Successfully Deployed.
 
-\`${COMMAND[*]}\`
+\`\`\`text
+${COMMAND[*]}
+\`\`\`
 
 <details><summary>Results</summary>
 


### PR DESCRIPTION
For #21 

Adds 3 new inputs: [`detach`, `prune`, `resolve_image`]

- If you set `detach` to anything but `true` it will add `--detach=false`
- If you set `prune` to anything but `false` it will add `--prune`
- If you set `resolve_image` to `changed` or `never` it will add `--resolve-image=changed|never`

Setting `resolve_image` to anything other than `always, changed, never` creates an Error annotation and uses default (omits the argument).

Also adds deploy command to the output and job summary to assist with debugging.

Output/Summary: https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml?query=branch%3Adeploy
README.md: https://github.com/cssnr/stack-deploy-action/tree/deploy?tab=readme-ov-file#readme

Use: `uses: cssnr/stack-deploy-action@deploy`