### PR TITLE
Add Standalone Docker Compose

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,4 +14,17 @@ jobs:
 
     steps:
       - name: "Update Tags"
+        id: tags
         uses: cssnr/update-version-tags-action@v1
+
+      - name: "Debug Tags"
+        run: |
+          echo "github.ref_name: ${{ github.ref_name }}"
+          echo "steps.tags.outputs.tags: ${{ steps.tags.outputs.tags }}"
+
+      - name: "Update Release Notes Action"
+        uses: smashedr/update-release-notes-action@master
+        continue-on-error: true
+        with:
+          tags: "${{ steps.tags.outputs.tags }}"
+          location: tail

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ !cancelled() && !github.event.act }}
         uses: ./
         with:
-          name: test_stack-deploy
+          name: test_stack-deploy-compose
           file: docker-compose.yaml
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}
@@ -117,7 +117,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: ./
         with:
-          name: test_stack-deploy
+          name: test_stack-deploy-compose
           file: docker-compose.yaml
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,7 @@ jobs:
           user: ${{ secrets.DOCKER_USER }}
           pass: ${{ secrets.DOCKER_PASS }}
           #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-          compose: true
+          mode: compose
           summary: false
 
       - name: "4: Write YAML"
@@ -124,7 +124,7 @@ jobs:
           user: ${{ secrets.DOCKER_USER }}
           pass: ${{ secrets.DOCKER_PASS }}
           #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-          compose: true
+          mode: compose
           registry_user: ${{ vars.DOCKER_HUB_USER }}
           registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,15 +83,40 @@ jobs:
       #    registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
       #    summary: false
 
-      - name: "3: Write YAML"
+      #- name: "3: Write YAML"
+      #  if: ${{ !cancelled() && !github.event.act }}
+      #  uses: teunmooij/yaml@v1
+      #  with:
+      #    to-file: "docker-compose.yaml"
+      #    data: |
+      #      {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+
+      #- name: "3: Test Compose"
+      #  if: ${{ !cancelled() && !github.event.act }}
+      #  uses: ./
+      #  with:
+      #    name: test_stack-deploy
+      #    file: docker-compose.yaml
+      #    host: ${{ secrets.DOCKER_HOST }}
+      #    port: ${{ secrets.DOCKER_PORT }}
+      #    user: ${{ secrets.DOCKER_USER }}
+      #    pass: ${{ secrets.DOCKER_PASS }}
+      #    #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+      #    compose: true
+
+      - name: "4: Write YAML"
         if: ${{ !cancelled() }}
         uses: teunmooij/yaml@v1
         with:
           to-file: "docker-compose.yaml"
           data: |
-            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+            {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
 
-      - name: "3: Test Compose"
+      - name: "4: Debug Compose"
+        run: |
+          cat "docker-compose.yaml"
+
+      - name: "4: Test Compose Auth"
         if: ${{ !cancelled() }}
         uses: ./
         with:
@@ -103,6 +128,8 @@ jobs:
           pass: ${{ secrets.DOCKER_PASS }}
           #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
           compose: true
+          registry_user: ${{ vars.DOCKER_HUB_USER }}
+          registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
 
       - name: "Schedule Failure Notification"
         if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,51 +37,51 @@ jobs:
       #  run: |
       #    cat "${GITHUB_EVENT_PATH}"
 
-      - name: "1: Write YAML"
-        if: ${{ !cancelled() }}
-        uses: teunmooij/yaml@v1
-        with:
-          to-file: "docker-compose.yaml"
-          data: |
-            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+      #- name: "1: Write YAML"
+      #  if: ${{ !cancelled() }}
+      #  uses: teunmooij/yaml@v1
+      #  with:
+      #    to-file: "docker-compose.yaml"
+      #    data: |
+      #      {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
 
-      - name: "1: Test Password"
-        if: ${{ !cancelled() }}
-        uses: ./
-        with:
-          name: test_stack-deploy
-          file: docker-compose.yaml
-          host: ${{ secrets.DOCKER_HOST }}
-          port: ${{ secrets.DOCKER_PORT }}
-          user: ${{ secrets.DOCKER_USER }}
-          pass: ${{ secrets.DOCKER_PASS }}
-          #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-          detach: false
-          resolve_image: "changed"
+      #- name: "1: Test Password"
+      #  if: ${{ !cancelled() }}
+      #  uses: ./
+      #  with:
+      #    name: test_stack-deploy
+      #    file: docker-compose.yaml
+      #    host: ${{ secrets.DOCKER_HOST }}
+      #    port: ${{ secrets.DOCKER_PORT }}
+      #    user: ${{ secrets.DOCKER_USER }}
+      #    pass: ${{ secrets.DOCKER_PASS }}
+      #    #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+      #    detach: false
+      #    resolve_image: "changed"
 
-      - name: "2: Write YAML"
-        if: ${{ !cancelled() && !github.event.act }}
-        uses: teunmooij/yaml@v1
-        with:
-          to-file: "docker-compose.yaml"
-          data: |
-            {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
+      #- name: "2: Write YAML"
+      #  if: ${{ !cancelled() && !github.event.act }}
+      #  uses: teunmooij/yaml@v1
+      #  with:
+      #    to-file: "docker-compose.yaml"
+      #    data: |
+      #      {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
 
-      - name: "2: Test SSH and Auth"
-        if: ${{ !cancelled() && !github.event.act }}
-        uses: ./
-        with:
-          name: test_stack-deploy
-          file: docker-compose.yaml
-          host: ${{ secrets.DOCKER_HOST }}
-          port: ${{ secrets.DOCKER_PORT }}
-          user: ${{ secrets.DOCKER_USER }}
-          #pass: ${{ secrets.DOCKER_PASS }}
-          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-          prune: true
-          registry_user: ${{ vars.DOCKER_HUB_USER }}
-          registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
-          summary: false
+      #- name: "2: Test SSH and Auth"
+      #  if: ${{ !cancelled() && !github.event.act }}
+      #  uses: ./
+      #  with:
+      #    name: test_stack-deploy
+      #    file: docker-compose.yaml
+      #    host: ${{ secrets.DOCKER_HOST }}
+      #    port: ${{ secrets.DOCKER_PORT }}
+      #    user: ${{ secrets.DOCKER_USER }}
+      #    #pass: ${{ secrets.DOCKER_PASS }}
+      #    ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+      #    prune: true
+      #    registry_user: ${{ vars.DOCKER_HUB_USER }}
+      #    registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
+      #    summary: false
 
       - name: "3: Write YAML"
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,72 +37,73 @@ jobs:
       #  run: |
       #    cat "${GITHUB_EVENT_PATH}"
 
-      #- name: "1: Write YAML"
-      #  if: ${{ !cancelled() }}
-      #  uses: teunmooij/yaml@v1
-      #  with:
-      #    to-file: "docker-compose.yaml"
-      #    data: |
-      #      {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+      - name: "1: Write YAML"
+        if: ${{ !cancelled() }}
+        uses: teunmooij/yaml@v1
+        with:
+          to-file: "docker-compose.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
 
-      #- name: "1: Test Password"
-      #  if: ${{ !cancelled() }}
-      #  uses: ./
-      #  with:
-      #    name: test_stack-deploy
-      #    file: docker-compose.yaml
-      #    host: ${{ secrets.DOCKER_HOST }}
-      #    port: ${{ secrets.DOCKER_PORT }}
-      #    user: ${{ secrets.DOCKER_USER }}
-      #    pass: ${{ secrets.DOCKER_PASS }}
-      #    #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-      #    detach: false
-      #    resolve_image: "changed"
+      - name: "1: Test Password"
+        if: ${{ !cancelled() }}
+        uses: ./
+        with:
+          name: test_stack-deploy
+          file: docker-compose.yaml
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          pass: ${{ secrets.DOCKER_PASS }}
+          #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          detach: false
+          resolve_image: "changed"
 
-      #- name: "2: Write YAML"
-      #  if: ${{ !cancelled() && !github.event.act }}
-      #  uses: teunmooij/yaml@v1
-      #  with:
-      #    to-file: "docker-compose.yaml"
-      #    data: |
-      #      {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
+      - name: "2: Write YAML"
+        if: ${{ !cancelled() && !github.event.act }}
+        uses: teunmooij/yaml@v1
+        with:
+          to-file: "docker-compose.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
 
-      #- name: "2: Test SSH and Auth"
-      #  if: ${{ !cancelled() && !github.event.act }}
-      #  uses: ./
-      #  with:
-      #    name: test_stack-deploy
-      #    file: docker-compose.yaml
-      #    host: ${{ secrets.DOCKER_HOST }}
-      #    port: ${{ secrets.DOCKER_PORT }}
-      #    user: ${{ secrets.DOCKER_USER }}
-      #    #pass: ${{ secrets.DOCKER_PASS }}
-      #    ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-      #    prune: true
-      #    registry_user: ${{ vars.DOCKER_HUB_USER }}
-      #    registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
-      #    summary: false
+      - name: "2: Test SSH and Auth"
+        if: ${{ !cancelled() && !github.event.act }}
+        uses: ./
+        with:
+          name: test_stack-deploy
+          file: docker-compose.yaml
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          #pass: ${{ secrets.DOCKER_PASS }}
+          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          prune: true
+          registry_user: ${{ vars.DOCKER_HUB_USER }}
+          registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
+          summary: false
 
-      #- name: "3: Write YAML"
-      #  if: ${{ !cancelled() && !github.event.act }}
-      #  uses: teunmooij/yaml@v1
-      #  with:
-      #    to-file: "docker-compose.yaml"
-      #    data: |
-      #      {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+      - name: "3: Write YAML"
+        if: ${{ !cancelled() && !github.event.act }}
+        uses: teunmooij/yaml@v1
+        with:
+          to-file: "docker-compose.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
 
-      #- name: "3: Test Compose"
-      #  if: ${{ !cancelled() && !github.event.act }}
-      #  uses: ./
-      #  with:
-      #    name: test_stack-deploy
-      #    file: docker-compose.yaml
-      #    host: ${{ secrets.DOCKER_HOST }}
-      #    port: ${{ secrets.DOCKER_PORT }}
-      #    user: ${{ secrets.DOCKER_USER }}
-      #    pass: ${{ secrets.DOCKER_PASS }}
-      #    #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
-      #    compose: true
+      - name: "3: Test Compose"
+        if: ${{ !cancelled() && !github.event.act }}
+        uses: ./
+        with:
+          name: test_stack-deploy
+          file: docker-compose.yaml
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          pass: ${{ secrets.DOCKER_PASS }}
+          #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          compose: true
+          summary: false
 
       - name: "4: Write YAML"
         if: ${{ !cancelled() }}
@@ -111,10 +112,6 @@ jobs:
           to-file: "docker-compose.yaml"
           data: |
             {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
-
-      - name: "4: Debug Compose"
-        run: |
-          cat "docker-compose.yaml"
 
       - name: "4: Test Compose Auth"
         if: ${{ !cancelled() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,15 +18,16 @@ on:
 env:
   PRIVATE_IMAGE: ${{ vars.PRIVATE_IMAGE || 'smashedr/alpine-private:latest' }}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Test"
     if: ${{ !contains(github.event.head_commit.message, '#notest') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    concurrency:
-      group: ${{ github.workflow }}
-      cancel-in-progress: true
 
     steps:
       - name: "Checkout"
@@ -81,6 +82,27 @@ jobs:
           registry_user: ${{ vars.DOCKER_HUB_USER }}
           registry_pass: ${{ secrets.DOCKER_HUB_PASS }}
           summary: false
+
+      - name: "3: Write YAML"
+        if: ${{ !cancelled() }}
+        uses: teunmooij/yaml@v1
+        with:
+          to-file: "docker-compose.yaml"
+          data: |
+            {"version":"3.8","services":{"alpine":{"image":"alpine:latest","command":"tail -f /dev/null"}}}
+
+      - name: "3: Test Compose"
+        if: ${{ !cancelled() }}
+        uses: ./
+        with:
+          name: test_stack-deploy
+          file: docker-compose.yaml
+          host: ${{ secrets.DOCKER_HOST }}
+          port: ${{ secrets.DOCKER_PORT }}
+          user: ${{ secrets.DOCKER_USER }}
+          pass: ${{ secrets.DOCKER_PASS }}
+          #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          compose: true
 
       - name: "Schedule Failure Notification"
         if: ${{ failure() && github.event_name == 'schedule' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,7 +113,7 @@ jobs:
           data: |
             {"version":"3.8","services":{"alpine":{"image":"${{ env.PRIVATE_IMAGE }}","command":"tail -f /dev/null"}}}
 
-      - name: "4: Test Compose Auth"
+      - name: "4: Test Compose SSH and Auth"
         if: ${{ !cancelled() }}
         uses: ./
         with:
@@ -122,8 +122,8 @@ jobs:
           host: ${{ secrets.DOCKER_HOST }}
           port: ${{ secrets.DOCKER_PORT }}
           user: ${{ secrets.DOCKER_USER }}
-          pass: ${{ secrets.DOCKER_PASS }}
-          #ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+          #pass: ${{ secrets.DOCKER_PASS }}
+          ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
           mode: compose
           registry_user: ${{ vars.DOCKER_HUB_USER }}
           registry_pass: ${{ secrets.DOCKER_HUB_PASS }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 > [!WARNING]  
 > This guide is a work in progress and may not be complete.
 
-This is a basic contributing guide and is a work in progress.
+Note: This guide is not updated for Compose but those tests work the same way.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ failed to create network test_stack-deploy_default: Error response from daemon: 
 ```
 
 </details>
-<details><summary>With SSH key, --prune, --detach=false and --resolve-image=changed</summary>
+<details><summary>With SSH Key, --prune, --detach=false and --resolve-image=changed</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -220,7 +220,7 @@ failed to create network test_stack-deploy_default: Error response from daemon: 
 ```
 
 </details>
-<details><summary>With All Inputs</summary>
+<details><summary>With All Swarm Inputs</summary>
 
 ```yaml
 - name: 'Stack Deploy'
@@ -279,6 +279,52 @@ failed to create network test_stack-deploy_default: Error response from daemon: 
 
 Note: these are the default arguments. If you use `compose_args` this will override the default arguments unless they are included.
 You can disable them by passing an empty string. For more details, see the compose up [docs](https://docs.docker.com/reference/cli/docker/compose/up/).
+
+</details>
+<details><summary>Compose with Private Image</summary>
+
+```yaml
+- name: 'Compose Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    name: 'stack-name'
+    file: 'docker-compose.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+    registry_host: 'ghcr.io'
+    registry_user: ${{ vars.GHCR_USER }}
+    registry_pass: ${{ secrets.GHCR_PASS }}
+    compose: true
+    compose_args: --remove-orphans --force-recreate
+```
+
+Note: these are the default arguments. If you use `compose_args` this will override the default arguments unless they are included.
+You can disable them by passing an empty string. For more details, see the compose up [docs](https://docs.docker.com/reference/cli/docker/compose/up/).
+
+</details>
+<details><summary>With All Compose Inputs</summary>
+
+```yaml
+- name: 'Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    name: 'stack-name'
+    file: 'docker-compose-swarm.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    pass: ${{ secrets.DOCKER_PASS }} # not needed with ssh_key
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }} # not needed with pass
+    env_file: 'stack.env'
+    registry_host: 'ghcr.io'
+    registry_user: ${{ vars.GHCR_USER }}
+    registry_pass: ${{ secrets.GHCR_PASS }}
+    compose: true
+    compose_args: --remove-orphans --force-recreate
+    summary: true
+```
 
 </details>
 <details><summary>Simple Workflow Example</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Contributing](#Contributing)
 
 > [!TIP]  
-> 🐳 Now works with vanilla Docker hosts using **Compose. No Swarm Required!**
+> 💡 Now works with vanilla Docker hosts using **Compose. No Swarm Required!**
 
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
 You can also optionally authenticate against a private registry using a username and password.
@@ -88,19 +88,20 @@ Use an empty string to override. For more details, see the compose up [docs](htt
 **host** - The hostname or IP address of the remote docker server to deploy too.
 If your hostname is behind a proxy like Cloudflare you will need to use the IP address.
 
-**pass/ssh_key** - You must provide either a `pass` or `ssh_key`.
+**pass/ssh_key** - You must provide either a `pass` or `ssh_key`, but not both.
 
 **env_file** - Variables in this file are exported before running stack deploy.
 To use a docker `env_file` specify it in your compose file and make it available in a previous step.
 If you need compose file templating this can also be done in a previous step.
+If using `compose: true` you can add the `compose_arg: --env-file stringArray`.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
 This is automatically set to `false` if you set `compose: true`.
 
-**resolve_image** - When the default `always` is used, this argument is omitted.
+**resolve_image** - When the default `always` is used, this argument is omitted. Swarm only.
 
-**registry_auth** - Set to `true` to deploy with `--with-registry-auth`.
+**registry_auth** - Set to `true` to deploy with `--with-registry-auth`. Swarm only.
 
 **registry_host** - To run `docker login` on another registry. Example: `ghcr.io`
 
@@ -251,7 +252,8 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
     compose_args: --remove-orphans --force-recreate
 ```
 
-Note: these are the default arguments. To remove them pass an empty string.
+Note: these are the default arguments. If you use `compose_args` this will override the default arguments unless they are included.
+You can disable them by passing an empty string.
 
 </details>
 <details><summary>Simple Workflow Example</summary>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Contributing](#Contributing)
 
 > [!TIP]  
-> 🐳 Now works with vanilla Docker hosts using Compose. **No Swarm Required!**
+> 🐳 Now works with vanilla Docker hosts using **Compose. No Swarm Required!**
 
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
 You can also optionally authenticate against a private registry using a username and password.
@@ -39,52 +39,51 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| Input         |   Required   | Default               | Description                               |
-| :------------ | :----------: | :-------------------- | :---------------------------------------- |
-| name          |   **Yes**    | -                     | Docker Stack/Project Name \*              |
-| file          |      -       | `docker-compose.yaml` | Docker Stack/Compose File                 |
-| compose       |      -       | `false`               | Uses Compose instead of Swarm \*          |
-| compose_args  |      -       | -                     | Additional Arguments for Compose \*       |
-| host          |   **Yes**    | -                     | Remote Docker Hostname or IP \*           |
-| port          |      -       | `22`                  | Remote Docker Port                        |
-| user          |   **Yes**    | -                     | Remote Docker Username                    |
-| pass          | or `ssh_key` | -                     | Remote Docker Password \*                 |
-| ssh_key       |  or `pass`   | -                     | Remote SSH Key File \*                    |
-| env_file      |      -       | -                     | Docker Environment File \*                |
-| detach        |      -       | `true`                | Detach Flag, `false` to disable \*        |
-| prune         |      -       | `false`               | Prune Flag, `true` to enable              |
-| resolve_image |      -       | `always`              | Resolve [`always`, `changed`, `never`] \* |
-| registry_auth |      -       | -                     | Enable Registry Authentication \*         |
-| registry_host |      -       | -                     | Registry Authentication Host \*           |
-| registry_user |      -       | -                     | Registry Authentication Username \*       |
-| registry_pass |      -       | -                     | Registry Authentication Password \*       |
-| summary       |      -       | `true`                | Add Job Summary \*                        |
+| Input          |   Required   | Default                             | Description                               |
+| :------------- | :----------: | :---------------------------------- | :---------------------------------------- |
+| name           |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
+| file           |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
+| _compose_      |      -       | `false`                             | Use **Compose** instead of Swarm \*       |
+| _compose_args_ |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
+| host           |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
+| port           |      -       | `22`                                | Remote Docker Port                        |
+| user           |   **Yes**    | -                                   | Remote Docker Username                    |
+| pass           | or `ssh_key` | -                                   | Remote Docker Password \*                 |
+| ssh_key        |  or `pass`   | -                                   | Remote SSH Key File \*                    |
+| env_file       |      -       | -                                   | Docker Environment File \*                |
+| detach         |      -       | `true`                              | Detach Flag, `false` to disable \*        |
+| prune          |      -       | `false`                             | Prune Flag, `true` to enable              |
+| resolve_image  |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
+| registry_auth  |      -       | -                                   | Enable Registry Authentication \*         |
+| registry_host  |      -       | -                                   | Registry Authentication Host \*           |
+| registry_user  |      -       | -                                   | Registry Authentication Username \*       |
+| registry_pass  |      -       | -                                   | Registry Authentication Password \*       |
+| summary        |      -       | `true`                              | Add Job Summary \*                        |
 
 _Swarm hosts, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/) for more details._  
 _Compose hosts, see the compose up [documentation](https://docs.docker.com/reference/cli/docker/compose/up/) for more details._
 
-<details><summary>📟 Click Here to see how command is generated</summary>
+<details><summary>📟 Click Here to see how the deployment command is generated</summary>
 
 ```shell
 if [[ "${INPUT_COMPOSE}" != "false" ]];then
     _type="Docker Compose"
     COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 else
-    _type="Docker Stack"
+    _type="Docker Swarm"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 fi
 ```
 
 </details>
 
-**name** - For Swarm this is the stack name and for Compose the project name.
+**name** - Stack name for Swarm and project name for Compose.
 
 **compose** - Set this to `true` to use `compose up` instead of `stack deploy` for non-swarm Docker hosts.
 
 **compose_args** - Arguments to pass to the `compose up` command. Only used for `compose: true` deployments.
-Detach `-d` is always passed. With no args the default is `--remove-orphans --force-recreate`.
-Use an empty string to override. For more details, see the compose up
-[docs](https://docs.docker.com/reference/cli/docker/compose/up/).
+The `detach` flag defaults to false for compose. With no args the default is `--remove-orphans --force-recreate`.
+Use an empty string to override. For more details, see the compose up [docs](https://docs.docker.com/reference/cli/docker/compose/up/).
 
 **host** - The hostname or IP address of the remote docker server to deploy too.
 If your hostname is behind a proxy like Cloudflare you will need to use the IP address.
@@ -97,6 +96,7 @@ If you need compose file templating this can also be done in a previous step.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
+This is automatically set to `false` if you set `compose: true`.
 
 **resolve_image** - When the default `always` is used, this argument is omitted.
 
@@ -390,11 +390,11 @@ https://github.com/cssnr/stack-deploy-action/network/dependents
 
 The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) are maintained.
 
-| Version&nbsp;Tag                                                                                                                                                                                                       | Example  | Target   | Rolling | Bugs | Feat. |
-| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
-| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=44cc10)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
-| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
-| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
+| Version&nbsp;Tag                                                                                                                                                                                                       | Rolling | Bugs | Feat. | Target   | Example  |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----: | :--: | :---: | :------- | :------- |
+| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=44cc10)](https://github.com/cssnr/stack-deploy-action/releases/latest) |   ✅    |  ✅  |  ✅   | `vN.x.x` | `vN`     |
+| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) |   ✅    |  ✅  |  ❌   | `vN.N.x` | `vN.N`   |
+| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           |   ❌    |  ❌  |  ❌   | `vN.N.N` | `vN.N.N` |
 
 You can view the release notes for each version on the [releases](https://github.com/cssnr/stack-deploy-action/releases) page.
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,8 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | registry_pass       |      -       | -                                   | Registry Authentication Password \*       |
 | summary             |      -       | `true`                              | Add Job Summary \*                        |
 
-> **¹** Compose Only  
-> **²** Swarm Only
-
-_For more information, see the [Swarm docs](https://docs.docker.com/reference/cli/docker/stack/deploy/) or [Compose docs](https://docs.docker.com/reference/cli/docker/compose/up/)._
+> **¹** Compose Only. View the [documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
+> **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 
@@ -114,7 +112,7 @@ This is automatically set to `false` if you set `mode: compose`. _Swarm only._
 
 To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 
-<details><summary>👀 View Example ✔️ Successful Job Summary</summary>
+<details><summary>👀 View Example Successful ✔️ Job Summary</summary>
 
 ---
 
@@ -145,7 +143,7 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 
 </details>
 
-<details><summary>👀 View Example ❌ Failure Job Summary</summary>
+<details><summary>👀 View Example Failure ❌ Job Summary</summary>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@
 - [Contributing](#Contributing)
 
 > [!TIP]  
-> 💡 Now works with vanilla Docker hosts using **Compose. No Swarm Required!**
+> 💡 Now works with vanilla Docker hosts using **Compose. No Swarm Required!**  
+> Just set `mode: compose`. See the [Inputs](#Inputs) for more details...
 
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
 You can also optionally authenticate against a private registry using a username and password.
@@ -60,9 +61,9 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | `registry_pass`      |      -       | -                                   | Registry Authentication Password \*       |
 | `summary`            |      -       | `true`                              | Add Job Summary \*                        |
 
-> **¹** Compose Only. View the [documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
-> **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
-> **\*** More Details Below...
+> **¹** Compose Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
+> **²** Swarm Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
+> \* More Details Below...
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 
@@ -95,17 +96,17 @@ If your hostname is behind a proxy like Cloudflare you will need to use the IP a
 **env_file** - Variables in this file are exported before running stack deploy.
 To use a docker `env_file` specify it in your compose file and make it available in a previous step.
 If you need compose file templating this can also be done in a previous step.
-If using `mode: compose` you can add the `compose_arg: --env-file stringArray`.
+If using `mode: compose` you can also add the `compose_arg: --env-file stringArray`.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
-This is automatically set to `false` if you set `mode: compose`. _Swarm only._
+Defaults to `false` in `mode: compose`. _Swarm only._
 
 **resolve_image** - When the default `always` is used, this argument is omitted. _Swarm only._
 
 **registry_auth** - Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
 
-**registry_host** - To run `docker login` on another registry. Example: `ghcr.io`
+**registry_host** - To run `docker login` on another registry. Example: `ghcr.io`.
 
 **registry_user/registry_pass** - Required to run `docker login` before stack deploy.
 

--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ https://github.com/cssnr/stack-deploy-action/network/dependents
 
 The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) are maintained.
 
-| Tag                                                                                                                                                                                                                           | Example  | Target   | Bugs | Feat. | Description                                               |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :--: | :---: | :-------------------------------------------------------- |
-| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=limegreen)](https://github.com/cssnr/stack-deploy-action/releases/latest)     | `vN`     | `vN.x.x` |  ✅  |  ✅   | Includes new features but is always backwards compatible. |
-| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=yellowgreen)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |  ✅  |  ❌   | Only receives bug fixes. This is the most stable tag.     |
-| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=orange)](https://github.com/cssnr/stack-deploy-action/releases/latest)                               | `vN.N.N` | `vN.N.N` |  ❌  |  ❌   | Not a rolling tag. **Not** recommended.                   |
+| Tag                                                                                                                                                                                                                    | Example  | Target   | Rolling | Bugs | Feat. |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
+| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)   | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
+| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
+| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
 
 You can view the release notes for each version on the [releases](https://github.com/cssnr/stack-deploy-action/releases) page.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 | Input         |   Required   | Default               | Description                               |
 | :------------ | :----------: | :-------------------- | :---------------------------------------- |
-| name          | _for swarm_  | -                     | Docker Stack Name for Swarm               |
+| name          |   **Yes**    | -                     | Docker Stack/Project Name \*              |
 | file          |      -       | `docker-compose.yaml` | Docker Stack/Compose File                 |
 | compose       |      -       | `false`               | Uses Compose instead of Swarm \*          |
 | compose_args  |      -       | -                     | Additional Arguments for Compose \*       |
@@ -59,10 +59,12 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | registry_pass |      -       | -                     | Registry Authentication Password \*       |
 | summary       |      -       | `true`                | Add Job Summary \*                        |
 
-_For additional details on inputs, see the stack deploy
-[documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/)._
+_Swarm hosts, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/) for more details._  
+_Compose hosts, see the compose up [documentation](https://docs.docker.com/reference/cli/docker/compose/up/) for more details._
 
-**compose** - Set this to `true` to use `compose up` instead of `stack deploy` for standalone Docker hosts.
+**name** - For Swarm this is the stack name and for Compose the project name.
+
+**compose** - Set this to `true` to use `compose up` instead of `stack deploy` for non-swarm Docker hosts.
 
 **compose_args** - Arguments to pass to the `compose up` command. Only used for `compose: true` deployments.
 Detach `-d` is always passed. With no args the default is `--remove-orphans --force-recreate`.
@@ -91,8 +93,7 @@ This will generate extra output in the logs and is useful for debugging deployme
 
 **summary** - Write a Summary for the job. To disable this set to `false`.
 
-To view a workflow run, click on a recent
-[Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
+To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 
 <details><summary>👀 View Example Job Summary</summary>
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ fi
 
 **name**: Stack name for Swarm and project name for Compose.
 
-**mode**: **¹** Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
+**mode**: _Compose only._ Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts.
 
-**args**: **¹** Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
+**args**: _Compose only._ Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
 The `detach` flag defaults to false for compose. With no args the default is `--remove-orphans --force-recreate`.
 Use an empty string to override. For more details, see the compose up
-[docs](https://docs.docker.com/reference/cli/docker/compose/up/). _Compose only._
+[docs](https://docs.docker.com/reference/cli/docker/compose/up/).
 
 **host**: The hostname or IP address of the remote docker server to deploy too.
 If your hostname is behind a proxy like Cloudflare you will need to use the IP address.
@@ -99,13 +99,13 @@ To use a docker `env_file` specify it in your compose file and make it available
 If you need compose file templating this can also be done in a previous step.
 If using `mode: compose` you can also add the `compose_arg: --env-file stringArray`.
 
-**detach**: **²** Set this to `false` to not exit immediately and wait for the services to converge.
+**detach**: _Swarm only._ Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
-Defaults to `false` in `mode: compose`. _Swarm only._
+Defaults to `false` in `mode: compose`.
 
-**resolve_image**: **²** When the default `always` is used, this argument is omitted. _Swarm only._
+**resolve_image**: _Swarm only._ When the default `always` is used, this argument is omitted.
 
-**registry_auth**: **²** Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
+**registry_auth**: _Swarm only._ Set to `true` to deploy with `--with-registry-auth`.
 
 **registry_host**: To run `docker login` on another registry. Example: `ghcr.io`.
 

--- a/README.md
+++ b/README.md
@@ -39,26 +39,28 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| Input          |   Required   | Default                             | Description                               |
-| :------------- | :----------: | :---------------------------------- | :---------------------------------------- |
-| name           |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
-| file           |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
-| _compose_      |      -       | `false`                             | Use **Compose** instead of Swarm \*       |
-| _compose_args_ |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
-| host           |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
-| port           |      -       | `22`                                | Remote Docker Port                        |
-| user           |   **Yes**    | -                                   | Remote Docker Username                    |
-| pass           | or `ssh_key` | -                                   | Remote Docker Password \*                 |
-| ssh_key        |  or `pass`   | -                                   | Remote SSH Key File \*                    |
-| env_file       |      -       | -                                   | Docker Environment File \*                |
-| detach         |      -       | `true`                              | Detach Flag, `false` to disable \*        |
-| prune          |      -       | `false`                             | Prune Flag, `true` to enable              |
-| resolve_image  |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
-| registry_auth  |      -       | -                                   | Enable Registry Authentication \*         |
-| registry_host  |      -       | -                                   | Registry Authentication Host \*           |
-| registry_user  |      -       | -                                   | Registry Authentication Username \*       |
-| registry_pass  |      -       | -                                   | Registry Authentication Password \*       |
-| summary        |      -       | `true`                              | Add Job Summary \*                        |
+| Input               |   Required   | Default                             | Description                               |
+| :------------------ | :----------: | :---------------------------------- | :---------------------------------------- |
+| name                |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
+| file                |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
+| _compose_           |      -       | `false`                             | Use **Compose** instead of Swarm \*       |
+| _compose_args_      |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
+| host                |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
+| port                |      -       | `22`                                | Remote Docker Port                        |
+| user                |   **Yes**    | -                                   | Remote Docker Username                    |
+| pass                | or `ssh_key` | -                                   | Remote Docker Password \*                 |
+| ssh_key             |  or `pass`   | -                                   | Remote SSH Key File \*                    |
+| env_file            |      -       | -                                   | Docker Environment File \*                |
+| detach **¹**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
+| prune **¹**         |      -       | `false`                             | Prune Flag, `true` to enable              |
+| resolve_image **¹** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
+| registry_auth       |      -       | -                                   | Enable Registry Authentication \*         |
+| registry_host       |      -       | -                                   | Registry Authentication Host \*           |
+| registry_user       |      -       | -                                   | Registry Authentication Username \*       |
+| registry_pass       |      -       | -                                   | Registry Authentication Password \*       |
+| summary             |      -       | `true`                              | Add Job Summary \*                        |
+
+> **¹** Swarm Hosts Only
 
 _Swarm hosts, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/) for more details._  
 _Compose hosts, see the compose up [documentation](https://docs.docker.com/reference/cli/docker/compose/up/) for more details._

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Contributing](#Contributing)
 
 > [!TIP]  
-> **Now works with vanilla Docker hosts using Compose. No Swarm Required!**
+> 🐳 Now works with vanilla Docker hosts using Compose. **No Swarm Required!**
 
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
 You can also optionally authenticate against a private registry using a username and password.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 > **¹** Swarm Hosts Only
 
-_Swarm hosts, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/) for more details._  
-_Compose hosts, see the compose up [documentation](https://docs.docker.com/reference/cli/docker/compose/up/) for more details._
+_For more information, see the [Swarm docs](https://docs.docker.com/reference/cli/docker/stack/deploy/) or [Compose docs](https://docs.docker.com/reference/cli/docker/compose/up/)._
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 
@@ -101,9 +100,9 @@ If using `compose: true` you can add the `compose_arg: --env-file stringArray`.
 This will generate extra output in the logs and is useful for debugging deployments.
 This is automatically set to `false` if you set `compose: true`.
 
-**resolve_image** - When the default `always` is used, this argument is omitted. Swarm only.
+**resolve_image** - When the default `always` is used, this argument is omitted. _Swarm only._
 
-**registry_auth** - Set to `true` to deploy with `--with-registry-auth`. Swarm only.
+**registry_auth** - Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
 
 **registry_host** - To run `docker login` on another registry. Example: `ghcr.io`
 
@@ -184,7 +183,7 @@ failed to create network test_stack-deploy_default: Error response from daemon: 
 
 💡 _Click on an example heading to expand or collapse the example._
 
-<details open><summary>With password, docker login and --with-registry-auth</summary>
+<details open><summary>With Password, docker login and --with-registry-auth</summary>
 
 ```yaml
 - name: 'Stack Deploy'

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 > **¹** Compose Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
 > **²** Swarm Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
-> \* More Details Below...
+> \* See Below for More Details...
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) 
 
 | Version&nbsp;Tag                                                                                                                                                                                                       | Example  | Target   | Rolling | Bugs | Feat. |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
-| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)   | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
+| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=44cc10)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
 | [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
 | [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 > **¹** Compose Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
 > **²** Swarm Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
-> \* See Below for More Details...
+> \* See Below for more details...
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ```shell
 if [[ "${INPUT_MODE}" == "swarm" ]];then
-    _type="Swarm"
+    DEPLOY_TYPE="Swarm"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 else
-    _type="Compose"
+    DEPLOY_TYPE="Compose"
     COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 fi
 ```

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ fi
 
 **name**: Stack name for Swarm and project name for Compose.
 
-**mode**¹: Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
+**mode**: **¹** Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
 
-**args**¹: Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
+**args**: **¹** Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
 The `detach` flag defaults to false for compose. With no args the default is `--remove-orphans --force-recreate`.
 Use an empty string to override. For more details, see the compose up
 [docs](https://docs.docker.com/reference/cli/docker/compose/up/). _Compose only._
@@ -99,13 +99,13 @@ To use a docker `env_file` specify it in your compose file and make it available
 If you need compose file templating this can also be done in a previous step.
 If using `mode: compose` you can also add the `compose_arg: --env-file stringArray`.
 
-**detach**²: Set this to `false` to not exit immediately and wait for the services to converge.
+**detach**: **²** Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
 Defaults to `false` in `mode: compose`. _Swarm only._
 
-**resolve_image**²: When the default `always` is used, this argument is omitted. _Swarm only._
+**resolve_image**: **²** When the default `always` is used, this argument is omitted. _Swarm only._
 
-**registry_auth**²: Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
+**registry_auth**: **²** Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
 
 **registry_host**: To run `docker login` on another registry. Example: `ghcr.io`.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Inputs](#Inputs)
 - [Examples](#Examples)
 - [Tags](#Tags)
+- [Features](#Features)
 - [Support](#Support)
 - [Contributing](#Contributing)
 
@@ -467,6 +468,17 @@ The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) 
 | [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           |   ❌    |  ❌  |  ❌   | `vN.N.N` | `vN.N.N` |
 
 You can view the release notes for each version on the [releases](https://github.com/cssnr/stack-deploy-action/releases) page.
+
+## Features
+
+- Deploy to a remote host using SSH or Password authentication.
+- Deploy using a remote context from the current working directory.
+- Deploy from a compose file to either a Docker Swarm or Compose host.
+- Displays output in logs, captures it in the Summary, and checks the status.
+- Allows logging into a private registry and deploying with registry auth.
+- Allows specifying all arguments for both Swarm and Compose deployments.
+
+Don't see your feature here? Request it below in the [Support](#Support) section.
 
 # Support
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 _Swarm hosts, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/) for more details._  
 _Compose hosts, see the compose up [documentation](https://docs.docker.com/reference/cli/docker/compose/up/) for more details._
 
+<details><summary>🖱️ Click Here to see how the script generates the command</summary>
+
+```shell
+if [[ "${INPUT_COMPOSE}" != "false" ]];then
+    _type="Docker Compose"
+    COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
+else
+    _type="Docker Stack"
+    COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
+fi
+```
+
+</details>
+
 **name** - For Swarm this is the stack name and for Compose the project name.
 
 **compose** - Set this to `true` to use `compose up` instead of `stack deploy` for non-swarm Docker hosts.

--- a/README.md
+++ b/README.md
@@ -39,26 +39,26 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| Input                 |   Required   | Default                             | Description                               |
-| :-------------------- | :----------: | :---------------------------------- | :---------------------------------------- |
-| `name`                |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
-| `file`                |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
-| `mode` **¹**          |      -       | `swarm`                             | Deploy Mode: [`swarm`, `compose`] \*      |
-| `args` **¹**          |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
-| `host`                |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
-| `port`                |      -       | `22`                                | Remote Docker Port                        |
-| `user`                |   **Yes**    | -                                   | Remote Docker Username                    |
-| `pass`                | or `ssh_key` | -                                   | Remote Docker Password \*                 |
-| `ssh_key`             |  or `pass`   | -                                   | Remote SSH Key File \*                    |
-| `env_file`            |      -       | -                                   | Docker Environment File \*                |
-| `detach` **²**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
-| `prune` **²**         |      -       | `false`                             | Prune Flag, `true` to enable              |
-| `resolve_image` **²** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
-| `registry_auth` **²** |      -       | -                                   | Enable Registry Authentication \*         |
-| `registry_host`       |      -       | -                                   | Registry Authentication Host \*           |
-| `registry_user`       |      -       | -                                   | Registry Authentication Username \*       |
-| `registry_pass`       |      -       | -                                   | Registry Authentication Password \*       |
-| `summary`             |      -       | `true`                              | Add Job Summary \*                        |
+| Input                |   Required   | Default                             | Description                               |
+| :------------------- | :----------: | :---------------------------------- | :---------------------------------------- |
+| `name`               |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
+| `file`               |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
+| `mode`**¹**          |      -       | `swarm`                             | Deploy Mode: [`swarm`, `compose`] \*      |
+| `args`**¹**          |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
+| `host`               |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
+| `port`               |      -       | `22`                                | Remote Docker Port                        |
+| `user`               |   **Yes**    | -                                   | Remote Docker Username                    |
+| `pass`               | or `ssh_key` | -                                   | Remote Docker Password \*                 |
+| `ssh_key`            |  or `pass`   | -                                   | Remote SSH Key File \*                    |
+| `env_file`           |      -       | -                                   | Docker Environment File \*                |
+| `detach`**²**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
+| `prune`**²**         |      -       | `false`                             | Prune Flag, `true` to enable              |
+| `resolve_image`**²** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
+| `registry_auth`**²** |      -       | -                                   | Enable Registry Authentication \*         |
+| `registry_host`      |      -       | -                                   | Registry Authentication Host \*           |
+| `registry_user`      |      -       | -                                   | Registry Authentication Username \*       |
+| `registry_pass`      |      -       | -                                   | Registry Authentication Password \*       |
+| `summary`            |      -       | `true`                              | Add Job Summary \*                        |
 
 > **¹** Compose Only. View the [documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
 > **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This is automatically set to `false` if you set `compose: true`.
 
 To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 
-<details><summary>👀 View Example Job Summary</summary>
+<details><summary>👀 View Example Successful Job Summary</summary>
 
 ---
 
@@ -139,6 +139,25 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 </details>
 
 ---
+
+</details>
+
+<details><summary>👀 View Example Failure Job Summary</summary>
+
+⛔ Swarm Stack `test_stack-deploy` Failed to Deploy!
+
+```text
+docker stack deploy -c docker-compose.yaml --detach=false --resolve-image=changed test_stack-deploy
+```
+
+<details><summary>Results</summary>
+
+```text
+Creating network test_stack-deploy_default
+failed to create network test_stack-deploy_default: Error response from daemon: network with name test_stack-deploy_default already exists
+```
+
+</details>
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | `pass`               | or `ssh_key` | -                                   | Remote Docker Password \*                 |
 | `ssh_key`            |  or `pass`   | -                                   | Remote SSH Key File \*                    |
 | `env_file`           |      -       | -                                   | Docker Environment File \*                |
-| `detach`**²**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
-| `prune`**²**         |      -       | `false`                             | Prune Flag, `true` to enable              |
+| `detach`**²**        |      -       | `true`                              | Detach Flag, `false`, to disable \*       |
+| `prune`**²**         |      -       | `false`                             | Prune Flag, `true`, to enable             |
 | `resolve_image`**²** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
 | `registry_auth`**²** |      -       | -                                   | Enable Registry Authentication \*         |
 | `registry_host`      |      -       | -                                   | Registry Authentication Host \*           |

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ _Compose hosts, see the compose up [documentation](https://docs.docker.com/refer
 
 ```shell
 if [[ "${INPUT_COMPOSE}" != "false" ]];then
-    _type="Docker Compose"
+    _type="Compose"
     COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 else
-    _type="Docker Swarm"
+    _type="Swarm"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 fi
 ```

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-
 
 ---
 
-🎉 Stack `test_stack-deploy` Successfully Deployed.
+🚀 Swarm Stack `test_stack-deploy` Successfully Deployed.
 
 ```text
 docker stack deploy --detach=false --resolve-image=changed -c docker-compose.yaml test_stack-deploy
@@ -253,7 +253,7 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 Note: these are the default arguments. If you use `compose_args` this will override the default arguments unless they are included.
-You can disable them by passing an empty string.
+You can disable them by passing an empty string. For more details, see the compose up [docs](https://docs.docker.com/reference/cli/docker/compose/up/).
 
 </details>
 <details><summary>Simple Workflow Example</summary>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [Support](#Support)
 - [Contributing](#Contributing)
 
+> [!TIP]  
 > **Now works with vanilla Docker hosts using Compose. No Swarm Required!**
 
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ https://github.com/cssnr/stack-deploy-action/network/dependents
 
 The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) are maintained.
 
-| Version Tag                                                                                                                                                                                                            | Example  | Target   | Rolling | Bugs | Feat. |
+| Version&nbsp;Tag                                                                                                                                                                                                       | Example  | Target   | Rolling | Bugs | Feat. |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
 | [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)   | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
 | [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ fi
 
 **name** - Stack name for Swarm and project name for Compose.
 
-**mode** - Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
+**mode ¹** - Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
 
-**args** - Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
+**args ¹** - Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
 The `detach` flag defaults to false for compose. With no args the default is `--remove-orphans --force-recreate`.
 Use an empty string to override. For more details, see the compose up
 [docs](https://docs.docker.com/reference/cli/docker/compose/up/). _Compose only._
@@ -99,13 +99,13 @@ To use a docker `env_file` specify it in your compose file and make it available
 If you need compose file templating this can also be done in a previous step.
 If using `mode: compose` you can also add the `compose_arg: --env-file stringArray`.
 
-**detach** - Set this to `false` to not exit immediately and wait for the services to converge.
+**detach ²** - Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
 Defaults to `false` in `mode: compose`. _Swarm only._
 
-**resolve_image** - When the default `always` is used, this argument is omitted. _Swarm only._
+**resolve_image ²** - When the default `always` is used, this argument is omitted. _Swarm only._
 
-**registry_auth** - Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
+**registry_auth ²** - Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
 
 **registry_host** - To run `docker login` on another registry. Example: `ghcr.io`.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 _Swarm hosts, see the stack deploy [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/) for more details._  
 _Compose hosts, see the compose up [documentation](https://docs.docker.com/reference/cli/docker/compose/up/) for more details._
 
-<details><summary>🖱️ Click Here to see how the script generates the command</summary>
+<details><summary>📟 Click Here to see how command is generated</summary>
 
 ```shell
 if [[ "${INPUT_COMPOSE}" != "false" ]];then
@@ -219,12 +219,13 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 </details>
-<details><summary>Standalone Compose with Defaults</summary>
+<details><summary>Compose with Defaults</summary>
 
 ```yaml
-- name: 'Stack Deploy'
+- name: 'Compose Deploy'
   uses: cssnr/stack-deploy-action@v1
   with:
+    name: 'stack-name'
     file: 'docker-compose.yaml'
     host: ${{ secrets.DOCKER_HOST }}
     port: ${{ secrets.DOCKER_PORT }}
@@ -234,12 +235,13 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 </details>
-<details><summary>Standalone Compose with Custom Arguments</summary>
+<details open><summary>Compose with Custom Arguments</summary>
 
 ```yaml
-- name: 'Stack Deploy'
+- name: 'Compose Deploy'
   uses: cssnr/stack-deploy-action@v1
   with:
+    name: 'stack-name'
     file: 'docker-compose.yaml'
     host: ${{ secrets.DOCKER_HOST }}
     port: ${{ secrets.DOCKER_PORT }}

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | `registry_pass`      |      -       | -                                   | Registry Authentication Password \*       |
 | `summary`            |      -       | `true`                              | Add Job Summary \*                        |
 
-> **¹** Compose Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
-> **²** Swarm Only. View the [Documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
+> **¹** Compose Only. View the [Docs](https://docs.docker.com/reference/cli/docker/compose/up/).  
+> **²** Swarm Only. View the [Docs](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
 > \* See Below for more details...
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
@@ -80,38 +80,38 @@ fi
 
 </details>
 
-**name**: Stack name for Swarm and project name for Compose.
+**name:** Stack name for Swarm and project name for Compose.
 
-**mode**: _Compose only._ Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts.
+**mode:** _Compose only._ Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts.
 
-**args**: _Compose only._ Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
+**args:** _Compose only._ Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
 The `detach` flag defaults to false for compose. With no args the default is `--remove-orphans --force-recreate`.
-Use an empty string to override. For more details, see the compose up
+Use an empty string to override. For more details, see the compose
 [docs](https://docs.docker.com/reference/cli/docker/compose/up/).
 
-**host**: The hostname or IP address of the remote docker server to deploy too.
+**host:** The hostname or IP address of the remote docker server to deploy too.
 If your hostname is behind a proxy like Cloudflare you will need to use the IP address.
 
-**pass/ssh_key**: You must provide either a `pass` or `ssh_key`, but not both.
+**pass/ssh_key:** You must provide either a `pass` or `ssh_key`, but not both.
 
-**env_file**: Variables in this file are exported before running stack deploy.
+**env_file:** Variables in this file are exported before running stack deploy.
 To use a docker `env_file` specify it in your compose file and make it available in a previous step.
 If you need compose file templating this can also be done in a previous step.
 If using `mode: compose` you can also add the `compose_arg: --env-file stringArray`.
 
-**detach**: _Swarm only._ Set this to `false` to not exit immediately and wait for the services to converge.
+**detach:** _Swarm only._ Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
 Defaults to `false` in `mode: compose`.
 
-**resolve_image**: _Swarm only._ When the default `always` is used, this argument is omitted.
+**resolve_image:** _Swarm only._ When the default `always` is used, this argument is omitted.
 
-**registry_auth**: _Swarm only._ Set to `true` to deploy with `--with-registry-auth`.
+**registry_auth:** _Swarm only._ Set to `true` to deploy with `--with-registry-auth`.
 
-**registry_host**: To run `docker login` on another registry. Example: `ghcr.io`.
+**registry_host:** To run `docker login` on another registry. Example: `ghcr.io`.
 
-**registry_user/registry_pass**: Required to run `docker login` before stack deploy.
+**registry_user/registry_pass:** Required to run `docker login` before stack deploy.
 
-**summary**: Write a Summary for the job. To disable this set to `false`.
+**summary:** Write a Summary for the job. To disable this set to `false`.
 
 To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 

--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ https://github.com/cssnr/stack-deploy-action/network/dependents
 
 The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) are maintained.
 
-| Tag                                                                                                                                                                                                                    | Example  | Target   | Rolling | Bugs | Feat. |
-| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
-| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)   | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
-| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
-| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
+| Tag                                                                                                                                                                                                         | Example  | Target   | Rolling | Bugs | Feat. |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
+| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=flat&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
+| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&flat&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)     | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
+| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?flat&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                               | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
 
 You can view the release notes for each version on the [releases](https://github.com/cssnr/stack-deploy-action/releases) page.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This is automatically set to `false` if you set `compose: true`.
 
 To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 
-<details><summary>👀 View Example Successful Job Summary</summary>
+<details><summary>👀 View Example ✔️ Successful Job Summary</summary>
 
 ---
 
@@ -142,7 +142,9 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 
 </details>
 
-<details><summary>👀 View Example Failure Job Summary</summary>
+<details><summary>👀 View Example ❌ Failure Job Summary</summary>
+
+---
 
 ⛔ Swarm Stack `test_stack-deploy` Failed to Deploy!
 
@@ -150,7 +152,7 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 docker stack deploy -c docker-compose.yaml --detach=false --resolve-image=changed test_stack-deploy
 ```
 
-<details><summary>Results</summary>
+<details open><summary>Errors</summary>
 
 ```text
 Creating network test_stack-deploy_default
@@ -158,6 +160,8 @@ failed to create network test_stack-deploy_default: Error response from daemon: 
 ```
 
 </details>
+
+---
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 > **¹** Compose Only. View the [documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
 > **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
-> \* See below for details.
+> **\*** More Details Below...
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | `summary`            |      -       | `true`                              | Add Job Summary \*                        |
 
 > **¹** Compose Only. View the [documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
-> **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).
+> **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).  
+> \* See below for details.
 
 <details><summary>📟 Click Here to see how the deployment command is generated</summary>
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&logo=git&logoColor=white&labelColor=585858&label=%20)](https://github.com/cssnr/stack-deploy-action/tags)
 [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&logo=git&logoColor=white&labelColor=585858&label=%20)](https://github.com/cssnr/stack-deploy-action/tags)
 [![GitHub Release Version](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?logo=git&logoColor=white&labelColor=585858&label=%20)](https://github.com/cssnr/stack-deploy-action/releases/latest)
-[![Release WF](https://img.shields.io/github/actions/workflow/status/cssnr/stack-deploy-action/release.yaml?logo=github&label=release)](https://github.com/cssnr/stack-deploy-action/actions/workflows/release.yaml)
-[![Test WF](https://img.shields.io/github/actions/workflow/status/cssnr/stack-deploy-action/test.yaml?logo=github&label=test)](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml)
-[![Lint WF](https://img.shields.io/github/actions/workflow/status/cssnr/stack-deploy-action/lint.yaml?logo=github&label=lint)](https://github.com/cssnr/stack-deploy-action/actions/workflows/lint.yaml)
+[![Workflow Release](https://img.shields.io/github/actions/workflow/status/cssnr/stack-deploy-action/release.yaml?logo=github&label=release)](https://github.com/cssnr/stack-deploy-action/actions/workflows/release.yaml)
+[![Workflow Test](https://img.shields.io/github/actions/workflow/status/cssnr/stack-deploy-action/test.yaml?logo=github&label=test)](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml)
+[![Workflow Lint](https://img.shields.io/github/actions/workflow/status/cssnr/stack-deploy-action/lint.yaml?logo=github&label=lint)](https://github.com/cssnr/stack-deploy-action/actions/workflows/lint.yaml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/cssnr/stack-deploy-action?logo=github&label=updated)](https://github.com/cssnr/stack-deploy-action/graphs/commit-activity)
 [![Codeberg Last Commit](https://img.shields.io/gitea/last-commit/cssnr/stack-deploy-action/master?gitea_url=https%3A%2F%2Fcodeberg.org%2F&logo=codeberg&logoColor=white&label=updated)](https://codeberg.org/cssnr/stack-deploy-action)
 [![GitHub Top Language](https://img.shields.io/github/languages/top/cssnr/stack-deploy-action?logo=htmx)](https://github.com/cssnr/stack-deploy-action)
@@ -21,6 +21,8 @@
 - [Support](#Support)
 - [Contributing](#Contributing)
 
+> **Now works with vanilla Docker hosts using Compose. No Swarm Required!**
+
 This action deploys a docker stack from a compose file to a remote docker host using SSH Password or Key File Authentication.
 You can also optionally authenticate against a private registry using a username and password.
 
@@ -36,10 +38,12 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| input         |   required   | default               | description                               |
-| ------------- | :----------: | --------------------- | ----------------------------------------- |
-| name          |   **Yes**    | -                     | Docker Stack Name                         |
-| file          |      -       | `docker-compose.yaml` | Docker Compose File                       |
+| Input         |   Required   | Default               | Description                               |
+| :------------ | :----------: | :-------------------- | :---------------------------------------- |
+| name          | _for swarm_  | -                     | Docker Stack Name for Swarm               |
+| file          |      -       | `docker-compose.yaml` | Docker Stack/Compose File                 |
+| compose       |      -       | `false`               | Uses Compose instead of Swarm \*          |
+| compose_args  |      -       | -                     | Additional Arguments for Compose \*       |
 | host          |   **Yes**    | -                     | Remote Docker Hostname or IP \*           |
 | port          |      -       | `22`                  | Remote Docker Port                        |
 | user          |   **Yes**    | -                     | Remote Docker Username                    |
@@ -48,7 +52,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | env_file      |      -       | -                     | Docker Environment File \*                |
 | detach        |      -       | `true`                | Detach Flag, `false` to disable \*        |
 | prune         |      -       | `false`               | Prune Flag, `true` to enable              |
-| resolve_image |      -       | `always`              | Options [`always`, `changed`, `never`] \* |
+| resolve_image |      -       | `always`              | Resolve [`always`, `changed`, `never`] \* |
 | registry_auth |      -       | -                     | Enable Registry Authentication \*         |
 | registry_host |      -       | -                     | Registry Authentication Host \*           |
 | registry_user |      -       | -                     | Registry Authentication Username \*       |
@@ -57,6 +61,13 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 _For additional details on inputs, see the stack deploy
 [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/)._
+
+**compose** - Set this to `true` to use `compose up` instead of `stack deploy` for standalone Docker hosts.
+
+**compose_args** - Arguments to pass to the `compose up` command. Only used for `compose: true` deployments.
+Detach `-d` is always passed. With no args the default is `--remove-orphans --force-recreate`.
+Use an empty string to override. For more details, see the compose up
+[docs](https://docs.docker.com/reference/cli/docker/compose/up/).
 
 **host** - The hostname or IP address of the remote docker server to deploy too.
 If your hostname is behind a proxy like Cloudflare you will need to use the IP address.
@@ -149,7 +160,6 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 </details>
-
 <details><summary>With SSH key, --prune, --detach=false and --resolve-image=changed</summary>
 
 ```yaml
@@ -168,7 +178,6 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 </details>
-
 <details><summary>With All Inputs</summary>
 
 ```yaml
@@ -194,7 +203,39 @@ verify: Service tdk8v42m0rvp9hz4rbfrtszb6 converged
 ```
 
 </details>
+<details><summary>Standalone Compose with Defaults</summary>
 
+```yaml
+- name: 'Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    file: 'docker-compose.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+    compose: true
+```
+
+</details>
+<details><summary>Standalone Compose with Custom Arguments</summary>
+
+```yaml
+- name: 'Stack Deploy'
+  uses: cssnr/stack-deploy-action@v1
+  with:
+    file: 'docker-compose.yaml'
+    host: ${{ secrets.DOCKER_HOST }}
+    port: ${{ secrets.DOCKER_PORT }}
+    user: ${{ secrets.DOCKER_USER }}
+    ssh_key: ${{ secrets.DOCKER_SSH_KEY }}
+    compose: true
+    compose_args: --remove-orphans --force-recreate
+```
+
+Note: these are the default arguments. To remove them pass an empty string.
+
+</details>
 <details><summary>Simple Workflow Example</summary>
 
 ```yaml
@@ -225,7 +266,6 @@ jobs:
 ```
 
 </details>
-
 <details><summary>Full Workflow Example</summary>
 
 ```yaml
@@ -333,7 +373,7 @@ https://github.com/cssnr/stack-deploy-action/network/dependents
 The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) are maintained.
 
 | Tag                                                                                                                                                                                                                           | Example  | Target   | Bugs | Feat. | Description                                               |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | :--: | :---: | --------------------------------------------------------- |
+| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :--: | :---: | :-------------------------------------------------------- |
 | [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=limegreen)](https://github.com/cssnr/stack-deploy-action/releases/latest)     | `vN`     | `vN.x.x` |  ✅  |  ✅   | Includes new features but is always backwards compatible. |
 | [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=yellowgreen)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |  ✅  |  ❌   | Only receives bug fixes. This is the most stable tag.     |
 | [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=orange)](https://github.com/cssnr/stack-deploy-action/releases/latest)                               | `vN.N.N` | `vN.N.N` |  ❌  |  ❌   | Not a rolling tag. **Not** recommended.                   |

--- a/README.md
+++ b/README.md
@@ -80,38 +80,38 @@ fi
 
 </details>
 
-**name** - Stack name for Swarm and project name for Compose.
+**name**: Stack name for Swarm and project name for Compose.
 
-**mode ¹** - Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
+**mode**¹: Set this to `compose` to use `compose up` instead of `stack deploy` for non-swarm hosts. _Compose only._
 
-**args ¹** - Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
+**args**¹: Compose arguments to pass to the `compose up` command. Only used for `mode: compose` deployments.
 The `detach` flag defaults to false for compose. With no args the default is `--remove-orphans --force-recreate`.
 Use an empty string to override. For more details, see the compose up
 [docs](https://docs.docker.com/reference/cli/docker/compose/up/). _Compose only._
 
-**host** - The hostname or IP address of the remote docker server to deploy too.
+**host**: The hostname or IP address of the remote docker server to deploy too.
 If your hostname is behind a proxy like Cloudflare you will need to use the IP address.
 
-**pass/ssh_key** - You must provide either a `pass` or `ssh_key`, but not both.
+**pass/ssh_key**: You must provide either a `pass` or `ssh_key`, but not both.
 
-**env_file** - Variables in this file are exported before running stack deploy.
+**env_file**: Variables in this file are exported before running stack deploy.
 To use a docker `env_file` specify it in your compose file and make it available in a previous step.
 If you need compose file templating this can also be done in a previous step.
 If using `mode: compose` you can also add the `compose_arg: --env-file stringArray`.
 
-**detach ²** - Set this to `false` to not exit immediately and wait for the services to converge.
+**detach**²: Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
 Defaults to `false` in `mode: compose`. _Swarm only._
 
-**resolve_image ²** - When the default `always` is used, this argument is omitted. _Swarm only._
+**resolve_image**²: When the default `always` is used, this argument is omitted. _Swarm only._
 
-**registry_auth ²** - Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
+**registry_auth**²: Set to `true` to deploy with `--with-registry-auth`. _Swarm only._
 
-**registry_host** - To run `docker login` on another registry. Example: `ghcr.io`.
+**registry_host**: To run `docker login` on another registry. Example: `ghcr.io`.
 
-**registry_user/registry_pass** - Required to run `docker login` before stack deploy.
+**registry_user/registry_pass**: Required to run `docker login` before stack deploy.
 
-**summary** - Write a Summary for the job. To disable this set to `false`.
+**summary**: Write a Summary for the job. To disable this set to `false`.
 
 To view a workflow run, click on a recent [Test](https://github.com/cssnr/stack-deploy-action/actions/workflows/test.yaml) job _(requires login)_.
 

--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ https://github.com/cssnr/stack-deploy-action/network/dependents
 
 The following rolling [tags](https://github.com/cssnr/stack-deploy-action/tags) are maintained.
 
-| Tag                                                                                                                                                                                                         | Example  | Target   | Rolling | Bugs | Feat. |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
-| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=flat&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
-| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&flat&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)     | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
-| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?flat&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                               | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
+| Version Tag                                                                                                                                                                                                            | Example  | Target   | Rolling | Bugs | Feat. |
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :-----: | :--: | :---: |
+| [![GitHub Tag Major](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest)   | `vN`     | `vN.x.x` |   ✅    |  ✅  |  ✅   |
+| [![GitHub Tag Minor](https://img.shields.io/github/v/tag/cssnr/stack-deploy-action?sort=semver&filter=!v*.*.*&style=for-the-badge&label=%20&color=blue)](https://github.com/cssnr/stack-deploy-action/releases/latest) | `vN.N`   | `vN.N.x` |   ✅    |  ✅  |  ❌   |
+| [![GitHub Release](https://img.shields.io/github/v/release/cssnr/stack-deploy-action?style=for-the-badge&label=%20&color=red)](https://github.com/cssnr/stack-deploy-action/releases/latest)                           | `vN.N.N` | `vN.N.N` |   ❌    |  ❌  |  ❌   |
 
 You can view the release notes for each version on the [releases](https://github.com/cssnr/stack-deploy-action/releases) page.
 

--- a/README.md
+++ b/README.md
@@ -39,26 +39,26 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 
 ## Inputs
 
-| Input               |   Required   | Default                             | Description                               |
-| :------------------ | :----------: | :---------------------------------- | :---------------------------------------- |
-| name                |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
-| file                |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
-| _mode_ **¹**        |      -       | `swarm`                             | Deploy Mode: [`swarm`, `compose`] \*      |
-| _args_ **¹**        |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
-| host                |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
-| port                |      -       | `22`                                | Remote Docker Port                        |
-| user                |   **Yes**    | -                                   | Remote Docker Username                    |
-| pass                | or `ssh_key` | -                                   | Remote Docker Password \*                 |
-| ssh_key             |  or `pass`   | -                                   | Remote SSH Key File \*                    |
-| env_file            |      -       | -                                   | Docker Environment File \*                |
-| detach **²**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
-| prune **²**         |      -       | `false`                             | Prune Flag, `true` to enable              |
-| resolve_image **²** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
-| registry_auth **²** |      -       | -                                   | Enable Registry Authentication \*         |
-| registry_host       |      -       | -                                   | Registry Authentication Host \*           |
-| registry_user       |      -       | -                                   | Registry Authentication Username \*       |
-| registry_pass       |      -       | -                                   | Registry Authentication Password \*       |
-| summary             |      -       | `true`                              | Add Job Summary \*                        |
+| Input                 |   Required   | Default                             | Description                               |
+| :-------------------- | :----------: | :---------------------------------- | :---------------------------------------- |
+| `name`                |   **Yes**    | -                                   | Docker Stack/Project Name \*              |
+| `file`                |      -       | `docker-compose.yaml`               | Docker Stack/Compose File                 |
+| `mode` **¹**          |      -       | `swarm`                             | Deploy Mode: [`swarm`, `compose`] \*      |
+| `args` **¹**          |      -       | `--remove-orphans --force-recreate` | Additional Arguments for **Compose** \*   |
+| `host`                |   **Yes**    | -                                   | Remote Docker Hostname or IP \*           |
+| `port`                |      -       | `22`                                | Remote Docker Port                        |
+| `user`                |   **Yes**    | -                                   | Remote Docker Username                    |
+| `pass`                | or `ssh_key` | -                                   | Remote Docker Password \*                 |
+| `ssh_key`             |  or `pass`   | -                                   | Remote SSH Key File \*                    |
+| `env_file`            |      -       | -                                   | Docker Environment File \*                |
+| `detach` **²**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
+| `prune` **²**         |      -       | `false`                             | Prune Flag, `true` to enable              |
+| `resolve_image` **²** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
+| `registry_auth` **²** |      -       | -                                   | Enable Registry Authentication \*         |
+| `registry_host`       |      -       | -                                   | Registry Authentication Host \*           |
+| `registry_user`       |      -       | -                                   | Registry Authentication Username \*       |
+| `registry_pass`       |      -       | -                                   | Registry Authentication Password \*       |
+| `summary`             |      -       | `true`                              | Add Job Summary \*                        |
 
 > **¹** Compose Only. View the [documentation](https://docs.docker.com/reference/cli/docker/compose/up/).  
 > **²** Swarm Only. View the [documentation](https://docs.docker.com/reference/cli/docker/stack/deploy/).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For more details see [action.yaml](action.yaml) and [src/main.sh](src/main.sh).
 | detach **¹**        |      -       | `true`                              | Detach Flag, `false` to disable \*        |
 | prune **¹**         |      -       | `false`                             | Prune Flag, `true` to enable              |
 | resolve_image **¹** |      -       | `always`                            | Resolve [`always`, `changed`, `never`] \* |
-| registry_auth       |      -       | -                                   | Enable Registry Authentication \*         |
+| registry_auth **¹** |      -       | -                                   | Enable Registry Authentication \*         |
 | registry_host       |      -       | -                                   | Registry Authentication Host \*           |
 | registry_user       |      -       | -                                   | Registry Authentication Username \*       |
 | registry_pass       |      -       | -                                   | Registry Authentication Password \*       |
@@ -98,7 +98,7 @@ If using `compose: true` you can add the `compose_arg: --env-file stringArray`.
 
 **detach** - Set this to `false` to not exit immediately and wait for the services to converge.
 This will generate extra output in the logs and is useful for debugging deployments.
-This is automatically set to `false` if you set `compose: true`.
+This is automatically set to `false` if you set `compose: true`. _Swarm only._
 
 **resolve_image** - When the default `always` is used, this argument is omitted. _Swarm only._
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,11 +13,11 @@ inputs:
     description: "Docker Compose File"
     required: false
     default: "docker-compose.yaml"
-  compose:
-    description: "Use Compose"
+  mode:
+    description: "Deploy Mode"
     required: false
-    default: "false"
-  compose_args:
+    default: "swarm"
+  args:
     description: "Compose Arguments"
     required: false
     default: "--remove-orphans --force-recreate"

--- a/action.yaml
+++ b/action.yaml
@@ -22,20 +22,20 @@ inputs:
     required: false
     default: "--remove-orphans --force-recreate"
   host:
-    description: "Docker Host"
+    description: "Remote Docker Host"
     required: true
   port:
-    description: "Docker Port"
+    description: "Remote Docker Port"
     required: false
     default: "22"
   user:
-    description: "Docker User"
+    description: "Remote Docker User"
     required: true
   pass:
-    description: "Docker Pass"
+    description: "Remote Docker Pass"
     required: false
   ssh_key:
-    description: "SSH Key File"
+    description: "Remote SSH Key File"
     required: false
   env_file:
     description: "Environment File"

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Docker Stack Deploy"
-description: "Deploy a Docker Compose or Stack to a Remote Host over SSH w/ Optional Registry Authentication"
+description: "Deploy a Docker Compose or Swarm Stack to a Remote Host over SSH with Password or Key File Authentication"
 author: "Shane"
 branding:
   icon: "layers"

--- a/action.yaml
+++ b/action.yaml
@@ -1,18 +1,33 @@
 name: "Docker Stack Deploy"
-description: "Deploy a Docker Stack to a Remote Host over SSH w/ Optional Registry Authentication"
+description: "Deploy a Docker Compose or Stack to a Remote Host over SSH w/ Optional Registry Authentication"
 author: "Shane"
 branding:
   icon: "layers"
   color: "green"
 
 inputs:
+  name:
+    description: "Docker Stack Name"
+    required: false
+  file:
+    description: "Docker Compose File"
+    required: false
+    default: "docker-compose.yaml"
+  compose:
+    description: "Use Compose"
+    required: false
+    default: "false"
+  compose_args:
+    description: "Compose Arguments"
+    required: false
+    default: "--remove-orphans --force-recreate"
   host:
     description: "Docker Host"
     required: true
   port:
     description: "Docker Port"
-    default: "22"
     required: false
+    default: "22"
   user:
     description: "Docker User"
     required: true
@@ -22,13 +37,6 @@ inputs:
   ssh_key:
     description: "SSH Key File"
     required: false
-  name:
-    description: "Docker Stack Name"
-    required: true
-  file:
-    description: "Docker Compose File"
-    required: false
-    default: "docker-compose.yaml"
   env_file:
     description: "Environment File"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,7 @@ branding:
 inputs:
   name:
     description: "Docker Stack Name"
-    required: false
+    required: true
   file:
     description: "Docker Compose File"
     required: false

--- a/src/main.sh
+++ b/src/main.sh
@@ -136,9 +136,11 @@ fi
 echo -e "::group::Deploying Docker ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
+set +e
 # shellcheck disable=SC2034
 STACK_RESULTS=$( "${COMMAND[@]}" 2>&1 | tee >(cat >&5) ;exit "${PIPESTATUS[0]}" )
 EXIT_STATUS="$?"
+set -e
 echo "::endgroup::"
 
 ## Write Summary

--- a/src/main.sh
+++ b/src/main.sh
@@ -79,10 +79,6 @@ if [[ -n "${INPUT_REGISTRY_USER}" && -n "${INPUT_REGISTRY_PASS}" ]];then
 fi
 
 EXTRA_ARGS=()
-if [[ -n "${INPUT_REGISTRY_AUTH}" ]];then
-    echo "::debug::Adding: --with-registry-auth"
-    EXTRA_ARGS+=("--with-registry-auth")
-fi
 if [[ "${INPUT_PRUNE}" != "false" ]];then
     echo "::debug::Adding: --prune"
     EXTRA_ARGS+=("--prune")
@@ -93,6 +89,10 @@ if [[ "${INPUT_COMPOSE}" != "false" ]];then
     read -r -a args <<< "${INPUT_COMPOSE_ARGS}"
     EXTRA_ARGS+=("${args[@]}")
 else
+    if [[ -n "${INPUT_REGISTRY_AUTH}" ]];then
+        echo "::debug::Adding: --with-registry-auth"
+        EXTRA_ARGS+=("--with-registry-auth")
+    fi
     if [[ "${INPUT_DETACH}" != "true" ]];then
         echo "::debug::Adding: --detach=false"
         EXTRA_ARGS+=("--detach=false")
@@ -108,14 +108,14 @@ else
 fi
 
 if [[ "${INPUT_COMPOSE}" != "false" ]];then
-    _type="Docker Compose"
+    _type="Compose"
     COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 else
-    _type="Docker Swarm"
+    _type="Swarm"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 fi
 
-echo -e "::group::Deploying ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
+echo -e "::group::Deploying Docker ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,7 +20,7 @@ function cleanup_trap() {
     exit "${_ST}"
 }
 
-## Set Variables
+## Check Variables
 
 #if [[ "${INPUT_COMPOSE}" != "false" && "${INPUT_COMPOSE_ARGS}" != "--remove-orphans --force-recreate" ]];then
 if [[ "${INPUT_COMPOSE}" == "false" ]];then
@@ -39,6 +39,8 @@ else
     fi
 fi
 
+## Setup Script
+
 SSH_DIR="/root/.ssh"
 
 echo "::group::Starting Stack Deploy Action ${GITHUB_ACTION_REF}"
@@ -47,11 +49,7 @@ echo "Script: ${0}"
 echo "Current Directory: $(pwd)"
 echo "Home Directory: ${HOME}"
 echo "SSH Directory: ${SSH_DIR}"
-echo "::endgroup::"
 
-## Setup SSH
-
-echo "::group::Setup SSH Directory and Known Hosts"
 mkdir -p "${SSH_DIR}" ~/.ssh
 chmod 0700 "${SSH_DIR}" ~/.ssh
 ssh-keyscan -p "${INPUT_PORT}" -H "${INPUT_HOST}" >> "${SSH_DIR}/known_hosts"

--- a/src/main.sh
+++ b/src/main.sh
@@ -39,6 +39,15 @@ chmod 0700 "${SSH_DIR}" ~/.ssh
 ssh-keyscan -p "${INPUT_PORT}" -H "${INPUT_HOST}" >> "${SSH_DIR}/known_hosts"
 echo "::endgroup::"
 
+
+## Setup SSH
+
+echo "::group::Setup SSH Directory and Known Hosts"
+mkdir -p "${SSH_DIR}" ~/.ssh
+chmod 0700 "${SSH_DIR}" ~/.ssh
+ssh-keyscan -p "${INPUT_PORT}" -H "${INPUT_HOST}" >> "${SSH_DIR}/known_hosts"
+echo "::endgroup::"
+
 ## Setup Authentication
 
 if [[ -z "${INPUT_SSH_KEY}" ]];then
@@ -96,11 +105,6 @@ fi
 ## Collect Arguments
 
 EXTRA_ARGS=()
-if [[ "${INPUT_PRUNE}" != "false" ]];then
-    echo "::debug::Adding: --prune"
-    EXTRA_ARGS+=("--prune")
-fi
-
 if [[ "${INPUT_COMPOSE}" != "false" ]];then
     echo "::debug::Adding: ${INPUT_COMPOSE_ARGS}"
     read -r -a args <<< "${INPUT_COMPOSE_ARGS}"
@@ -113,6 +117,10 @@ else
     if [[ "${INPUT_DETACH}" != "true" ]];then
         echo "::debug::Adding: --detach=false"
         EXTRA_ARGS+=("--detach=false")
+    fi
+    if [[ "${INPUT_PRUNE}" != "false" ]];then
+        echo "::debug::Adding: --prune"
+        EXTRA_ARGS+=("--prune")
     fi
     if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
         if [[ "${INPUT_RESOLVE_IMAGE}" == "changed" || "${INPUT_RESOLVE_IMAGE}" == "never" ]];then
@@ -153,4 +161,5 @@ if [[ "${INPUT_SUMMARY}" == "true" ]];then
         echo "::error::Failed to Write Job Summary!"
 fi
 
+echo "::debug::EXIT_STATUS: ${EXIT_STATUS}"
 exit "${EXIT_STATUS}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -111,11 +111,11 @@ if [[ "${INPUT_COMPOSE}" != "false" ]];then
     _type="Docker Compose"
     COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 else
-    _type="Docker Stack"
+    _type="Docker Swarm"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 fi
 
-echo -e "::group::Deploying ${_type} \u001b[36;1m${INPUT_NAME}"
+echo -e "::group::Deploying ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034

--- a/src/main.sh
+++ b/src/main.sh
@@ -3,6 +3,7 @@
 
 set -e
 
+# shellcheck disable=SC2317
 function cleanup_trap() {
     _ST="$?"
     if [[ -z "${INPUT_SSH_KEY}" ]];then

--- a/src/main.sh
+++ b/src/main.sh
@@ -22,8 +22,21 @@ function cleanup_trap() {
 
 ## Set Variables
 
-if [[ "${INPUT_COMPOSE}" != "false" && "${INPUT_COMPOSE_ARGS}" != "--remove-orphans --force-recreate" ]];then
-    echo "::warning::You set compose_args but compose is false!"
+#if [[ "${INPUT_COMPOSE}" != "false" && "${INPUT_COMPOSE_ARGS}" != "--remove-orphans --force-recreate" ]];then
+if [[ "${INPUT_COMPOSE}" == "false" ]];then
+    if [[ "${INPUT_COMPOSE_ARGS}" != "--remove-orphans --force-recreate" ]];then
+        echo "::warning::You set compose_args but compose is false!"
+    fi
+else
+    if [[ "${INPUT_DETACH}" != "true" ]];then
+        echo "::warning::You set detach but compose is true!"
+    fi
+    if [[ "${INPUT_PRUNE}" != "false" ]];then
+        echo "::warning::You set prune but compose is true!"
+    fi
+    if [[ "${INPUT_RESOLVE_IMAGE}" != "always" ]];then
+        echo "::warning::You set resolve_image but compose is true!"
+    fi
 fi
 
 SSH_DIR="/root/.ssh"
@@ -34,11 +47,7 @@ echo "Script: ${0}"
 echo "Current Directory: $(pwd)"
 echo "Home Directory: ${HOME}"
 echo "SSH Directory: ${SSH_DIR}"
-mkdir -p "${SSH_DIR}" ~/.ssh
-chmod 0700 "${SSH_DIR}" ~/.ssh
-ssh-keyscan -p "${INPUT_PORT}" -H "${INPUT_HOST}" >> "${SSH_DIR}/known_hosts"
 echo "::endgroup::"
-
 
 ## Setup SSH
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -137,7 +137,8 @@ echo -e "::group::Deploying Docker ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034
-STACK_RESULTS=$("${COMMAND[@]}" 2>&1 | tee >(cat >&5));EXIT_STATUS=${PIPESTATUS[0]}
+STACK_RESULTS=$( "${COMMAND[@]}" 2>&1 | tee >(cat >&5) ;exit "${PIPESTATUS[0]}" )
+EXIT_STATUS="$?"
 echo "::endgroup::"
 
 ## Write Summary

--- a/src/main.sh
+++ b/src/main.sh
@@ -137,8 +137,7 @@ echo -e "::group::Deploying Docker ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034
-STACK_RESULTS=$("${COMMAND[@]}" 2>&1 | tee >(cat >&5))
-EXIT_STATUS=${PIPESTATUS[0]}
+STACK_RESULTS=$("${COMMAND[@]}" 2>&1 | tee >(cat >&5));EXIT_STATUS=${PIPESTATUS[0]}
 echo "::endgroup::"
 
 ## Write Summary

--- a/src/main.sh
+++ b/src/main.sh
@@ -147,14 +147,14 @@ fi
 ## Deploy Stack
 
 if [[ "${INPUT_MODE}" == "swarm" ]];then
-    _type="Swarm"
+    DEPLOY_TYPE="Swarm"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 else
-    _type="Compose"
+    DEPLOY_TYPE="Compose"
     COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 fi
 
-echo -e "::group::Deploying Docker ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
+echo -e "::group::Deploying Docker ${DEPLOY_TYPE} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 set +e

--- a/src/main.sh
+++ b/src/main.sh
@@ -138,6 +138,7 @@ echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034
 STACK_RESULTS=$("${COMMAND[@]}" 2>&1 | tee >(cat >&5))
+_EXIT="$?"
 echo "::endgroup::"
 
 ## Write Summary
@@ -148,3 +149,5 @@ if [[ "${INPUT_SUMMARY}" == "true" ]];then
     source /src/summary.sh >> "${GITHUB_STEP_SUMMARY}" ||\
         echo "::error::Failed to Write Job Summary!"
 fi
+
+exit "${_EXIT}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -11,8 +11,8 @@ function cleanup_trap() {
             "sed -i '/docker-stack-deploy-action/d' ~/.ssh/authorized_keys"
     fi
     if [[ "${_ST}" != "0" ]]; then
-        echo -e "⛔ \u001b[31;1mFailed to deploy stack!"
-        echo "::error::Failed to deploy stack. See logs for details..."
+        echo -e "⛔ \u001b[31;1mFailed to deploy stack ${INPUT_NAME}"
+        echo "::error::Failed to deploy stack ${INPUT_NAME}. See logs for details..."
     else
         echo -e "✅ \u001b[32;1mFinished Success"
     fi
@@ -109,13 +109,13 @@ fi
 
 if [[ "${INPUT_COMPOSE}" != "false" ]];then
     _type="Docker Compose"
-    COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
+    COMMAND=("docker" "compose" "-f" "${INPUT_FILE}" "-p" "${INPUT_NAME}" "up" "-d" "-y" "${EXTRA_ARGS[@]}")
 else
-    _type="Docker Stack \u001b[36;1m${INPUT_NAME}"
+    _type="Docker Stack"
     COMMAND=("docker" "stack" "deploy" "-c" "${INPUT_FILE}" "${EXTRA_ARGS[@]}" "${INPUT_NAME}")
 fi
 
-echo -e "::group::Deploying ${_type}"
+echo -e "::group::Deploying ${_type} \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034

--- a/src/main.sh
+++ b/src/main.sh
@@ -138,7 +138,7 @@ echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034
 STACK_RESULTS=$("${COMMAND[@]}" 2>&1 | tee >(cat >&5))
-_EXIT="$?"
+EXIT_STATUS=${PIPESTATUS[0]}
 echo "::endgroup::"
 
 ## Write Summary
@@ -150,4 +150,4 @@ if [[ "${INPUT_SUMMARY}" == "true" ]];then
         echo "::error::Failed to Write Job Summary!"
 fi
 
-exit "${_EXIT}"
+exit "${EXIT_STATUS}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -119,7 +119,7 @@ echo -e "::group::Deploying ${_type} Stack: \u001b[36;1m${INPUT_NAME}"
 echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 # shellcheck disable=SC2034
-STACK_RESULTS=$("${COMMAND[@]}" | tee >(cat >&5))
+STACK_RESULTS=$("${COMMAND[@]}" 2>&1 | tee >(cat >&5))
 echo "::endgroup::"
 
 if [[ "${INPUT_SUMMARY}" == "true" ]];then

--- a/src/main.sh
+++ b/src/main.sh
@@ -139,7 +139,7 @@ echo -e "\u001b[33;1m${COMMAND[*]}\n"
 exec 5>&1
 set +e
 # shellcheck disable=SC2034
-STACK_RESULTS=$( "${COMMAND[@]}" 2>&1 | tee >(cat >&5) ;exit "${PIPESTATUS[0]}" )
+STACK_RESULTS=$( "${COMMAND[@]}" 2>&1 | tee >(cat >&5) ; exit "${PIPESTATUS[0]}" )
 EXIT_STATUS="$?"
 set -e
 echo "::endgroup::"

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -2,10 +2,10 @@
 # shellcheck disable=SC2154
 
 if [[ "${EXIT_STATUS}" == 0 ]];then
-    _result="🚀 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed."
+    _result="🚀 ${DEPLOY_TYPE} Stack \`${INPUT_NAME}\` Successfully Deployed."
     _details="<details><summary>Results</summary>"
 else
-    _result="⛔ ${_type} Stack \`${INPUT_NAME}\` Failed to Deploy!"
+    _result="⛔ ${DEPLOY_TYPE} Stack \`${INPUT_NAME}\` Failed to Deploy!"
     _details="<details open><summary>Errors</summary>"
 fi
 

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2154
 cat << EOM
 ## Stack Deploy Action
 
-🎉 Stack \`${INPUT_NAME}\` Successfully Deployed.
+🎉 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed.
 
 \`\`\`text
 ${COMMAND[*]}

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2154
 
-echo -e "## Stack Deploy Action\n"
-
 if [[ "${EXIT_STATUS}" == 0 ]];then
-    echo "🚀 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed."
+    _result="🚀 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed."
+    _details="<details><summary>Results</summary>"
 else
-    echo "⛔ ${_type} Stack \`${INPUT_NAME}\` Failed to Deploy!"
+    _result="⛔ ${_type} Stack \`${INPUT_NAME}\` Failed to Deploy!"
+    _details="<details open><summary>Errors</summary>"
 fi
 
 cat << EOM
+## Stack Deploy Action
+
+${_result}
 
 \`\`\`text
 ${COMMAND[*]}
 \`\`\`
 
-<details><summary>Results</summary>
+${_details}
 
 \`\`\`text
 ${STACK_RESULTS}

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -4,7 +4,7 @@
 cat << EOM
 ## Stack Deploy Action
 
-🎉 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed.
+🚀 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed.
 
 \`\`\`text
 ${COMMAND[*]}
@@ -18,7 +18,7 @@ ${STACK_RESULTS}
 
 </details>
 
-[Report an issue or request a feature](https://github.com/cssnr/stack-deploy-action?tab=readme-ov-file#readme)
+[View Documentation, Report Issues or Request Features](https://github.com/cssnr/stack-deploy-action?tab=readme-ov-file#readme)
 
 ---
 EOM

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-
 # shellcheck disable=SC2154
-cat << EOM
-## Stack Deploy Action
 
-🚀 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed.
+echo -e "## Stack Deploy Action\n"
+
+if [[ "${EXIT_STATUS}" == 0 ]];then
+    echo "🚀 ${_type} Stack \`${INPUT_NAME}\` Successfully Deployed."
+else
+    echo "⛔ ${_type} Stack \`${INPUT_NAME}\` Failed to Deploy!"
+fi
+
+cat << EOM
 
 \`\`\`text
 ${COMMAND[*]}


### PR DESCRIPTION
# Overview

Adds:

- Deploying with Compose (non-swarm)
- Error Status and Logs in Job Summary

Fixes:

- Detect stack deploy failures

## Checklist

- [x] Fix capturing compose output
- [x] Look into `--pull` argument
- [x] Verify authentication
- [x] Verify environment file
- [x] Cleanup: `test.yaml`
- [x] Name for arg: `compose`
`mode: swarm|compose`
- [x] Name for arg: `compose_args`
`args:`
- [x] Verify default compose arguments
`--remove-orphans --force-recreate`