### PR TITLE
[FIX] Make --detach argument explicit to handle future Docker Swarm changes

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -135,8 +135,7 @@ if [[ "${INPUT_MODE}" == "swarm" ]];then
     if [[ "${INPUT_DETACH}" == "true" ]];then
         echo "::debug::Adding: --detach=true"
         EXTRA_ARGS+=("--detach=true")
-    fi
-    if [[ "${INPUT_DETACH}" != "true" ]];then
+    else
         echo "::debug::Adding: --detach=false"
         EXTRA_ARGS+=("--detach=false")
     fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -132,6 +132,10 @@ if [[ "${INPUT_MODE}" == "swarm" ]];then
         echo "::debug::Adding: --with-registry-auth"
         EXTRA_ARGS+=("--with-registry-auth")
     fi
+    if [[ "${INPUT_DETACH}" == "true" ]];then
+        echo "::debug::Adding: --detach=true"
+        EXTRA_ARGS+=("--detach=true")
+    fi
     if [[ "${INPUT_DETACH}" != "true" ]];then
         echo "::debug::Adding: --detach=false"
         EXTRA_ARGS+=("--detach=false")


### PR DESCRIPTION
# Overview

![{9690BED1-4C5D-46DA-951E-8381C9D669E1}](https://github.com/user-attachments/assets/284be890-f0dd-421b-bd70-20bd6190faeb)

```sh
Since --detach=false was not specified, tasks will be created in the background.
In a future release, --detach=false will become the default.
```

Docker Swarm will set --detach argument to false in the future, which will break the code unless specified explicitly. I've added another if block to set this argument to true. This will also remove the warning in the logs.

## Checklist
- [ ] Verify the Required Checks are Passing
- [ ] Document changes in the [README.md](../blob/master/README.md) (for new features)